### PR TITLE
fix(unocss): honor allowUnprefixed=false without leaking unprefixed theme tokens

### DIFF
--- a/packages/unocss/src/common/rules.ts
+++ b/packages/unocss/src/common/rules.ts
@@ -2,23 +2,30 @@
  * 规则生成函数
  */
 
+function resolveThemeTokenKey(token: string, themeTokenPrefix?: string) {
+  if (!themeTokenPrefix)
+    return token
+
+  return `${themeTokenPrefix}-${token}`
+}
+
 /**
  * 创建颜色类规则
  */
-export function createColorRules(prefix: string) {
+export function createColorRules(prefix: string, themeTokenPrefix?: string) {
   const p = prefix ? `${prefix}-` : ''
   
   return [
     // ${prefix}-color-primary 或 ${prefix}-c-primary -> color: var(--${antPrefix}-color-primary)
     [new RegExp(`^${p}(?:color|c)-(.+)$`), ([_, c]: [any, any], { theme }: any) => {
-      const color = (theme.colors as any)?.[c!]
+      const color = (theme.colors as any)?.[resolveThemeTokenKey(c!, themeTokenPrefix)]
       if (color)
         return { color }
     }],
 
     // ${prefix}-bg-container -> background-color: var(--${antPrefix}-color-bg-container)
     [new RegExp(`^${p}bg-(.+)$`), ([_, c]: [any, any], { theme }: any) => {
-      const color = (theme.colors as any)?.[c!]
+      const color = (theme.colors as any)?.[resolveThemeTokenKey(c!, themeTokenPrefix)]
       if (color)
         return { 'background-color': color }
     }],
@@ -28,51 +35,51 @@ export function createColorRules(prefix: string) {
 /**
  * 创建边框颜色规则
  */
-export function createBorderRules(prefix: string) {
+export function createBorderRules(prefix: string, themeTokenPrefix?: string) {
   const p = prefix ? `${prefix}-` : ''
   
   return [
     // ${prefix}-border 或 ${prefix}-b -> border-color: var(--${antPrefix}-color-border) (DEFAULT)
     [new RegExp(`^${p}(?:border|b)$`), (_: any, { theme }: any) => {
-      const color = (theme.colors as any)?.border
+      const color = (theme.colors as any)?.[resolveThemeTokenKey('border', themeTokenPrefix)]
       if (color)
         return { 'border-color': color }
     }],
     // ${prefix}-border-primary 或 ${prefix}-b-primary -> border-color: ...
     [new RegExp(`^${p}(?:border|b)-(.+)$`), ([_, c]: [any, any], { theme }: any) => {
-      const color = (theme.colors as any)?.[c!]
+      const color = (theme.colors as any)?.[resolveThemeTokenKey(c!, themeTokenPrefix)]
       if (color)
         return { 'border-color': color }
     }],
     // 方向性 border: bt/border-t, br/border-r, bb/border-b, bl/border-l
     [new RegExp(`^${p}(?:border-t|bt)-(.+)$`), ([_, c]: [any, any], { theme }: any) => {
-      const color = (theme.colors as any)?.[c!]
+      const color = (theme.colors as any)?.[resolveThemeTokenKey(c!, themeTokenPrefix)]
       if (color)
         return { 'border-top-color': color }
     }],
     [new RegExp(`^${p}(?:border-r|br)-(.+)$`), ([_, c]: [any, any], { theme }: any) => {
-      const color = (theme.colors as any)?.[c!]
+      const color = (theme.colors as any)?.[resolveThemeTokenKey(c!, themeTokenPrefix)]
       if (color)
         return { 'border-right-color': color }
     }],
     [new RegExp(`^${p}(?:border-b|bb)-(.+)$`), ([_, c]: [any, any], { theme }: any) => {
-      const color = (theme.colors as any)?.[c!]
+      const color = (theme.colors as any)?.[resolveThemeTokenKey(c!, themeTokenPrefix)]
       if (color)
         return { 'border-bottom-color': color }
     }],
     [new RegExp(`^${p}(?:border-l|bl)-(.+)$`), ([_, c]: [any, any], { theme }: any) => {
-      const color = (theme.colors as any)?.[c!]
+      const color = (theme.colors as any)?.[resolveThemeTokenKey(c!, themeTokenPrefix)]
       if (color)
         return { 'border-left-color': color }
     }],
     // 双向 border: bx/border-x, by/border-y
     [new RegExp(`^${p}(?:border-x|bx)-(.+)$`), ([_, c]: [any, any], { theme }: any) => {
-      const color = (theme.colors as any)?.[c!]
+      const color = (theme.colors as any)?.[resolveThemeTokenKey(c!, themeTokenPrefix)]
       if (color)
         return { 'border-left-color': color, 'border-right-color': color }
     }],
     [new RegExp(`^${p}(?:border-y|by)-(.+)$`), ([_, c]: [any, any], { theme }: any) => {
-      const color = (theme.colors as any)?.[c!]
+      const color = (theme.colors as any)?.[resolveThemeTokenKey(c!, themeTokenPrefix)]
       if (color)
         return { 'border-top-color': color, 'border-bottom-color': color }
     }],
@@ -156,19 +163,20 @@ export function createSpacingRules(prefix: string, antPrefix: string) {
  * @param prefix class 前缀
  * @param themeKey 主题键名，'fontSize' 或 'text'
  */
-export function createTextRules(prefix: string, themeKey: 'fontSize' | 'text' = 'fontSize') {
+export function createTextRules(prefix: string, themeKey: 'fontSize' | 'text' = 'fontSize', themeTokenPrefix?: string) {
   const p = prefix ? `${prefix}-` : ''
   
   return [
     // ${prefix}-text-lg -> font-size: 16px (var)
     [new RegExp(`^${p}text-(.+)$`), ([_, s]: [any, any], { theme }: any) => {
+      const key = resolveThemeTokenKey(s!, themeTokenPrefix)
       if (themeKey === 'fontSize') {
-        const v = (theme.fontSize as any)?.[s!]
+        const v = (theme.fontSize as any)?.[key]
         if (v)
           return { 'font-size': v }
       }
       else {
-        const textConfig = (theme.text as any)?.[s!]
+        const textConfig = (theme.text as any)?.[key]
         if (textConfig?.fontSize) {
           return { 'font-size': textConfig.fontSize }
         }
@@ -182,61 +190,61 @@ export function createTextRules(prefix: string, themeKey: 'fontSize' | 'text' = 
  * @param prefix class 前缀
  * @param themeKey 主题键名，'borderRadius' 或 'radius'
  */
-export function createRoundedRules(prefix: string, themeKey: 'borderRadius' | 'radius' = 'borderRadius') {
+export function createRoundedRules(prefix: string, themeKey: 'borderRadius' | 'radius' = 'borderRadius', themeTokenPrefix?: string) {
   const p = prefix ? `${prefix}-` : ''
   
   return [
     // ${prefix}-rounded -> border-radius: var(--${antPrefix}-border-radius) (DEFAULT)
     [new RegExp(`^${p}(?:rounded|rd)$`), (_: any, { theme }: any) => {
-      const v = (theme[themeKey] as any)?.DEFAULT
+      const v = (theme[themeKey] as any)?.[resolveThemeTokenKey('DEFAULT', themeTokenPrefix)]
       if (v)
         return { 'border-radius': v }
     }],
     // ${prefix}-rounded-sm 或 ${prefix}-rd-sm -> border-radius: 4px (var)
     [new RegExp(`^${p}(?:rounded|rd)-(.+)$`), ([_, s]: [any, any], { theme }: any) => {
-      const v = (theme[themeKey] as any)?.[s!]
+      const v = (theme[themeKey] as any)?.[resolveThemeTokenKey(s!, themeTokenPrefix)]
       if (v)
         return { 'border-radius': v }
     }],
     // 角落圆角: rounded-tl, rounded-tr, rounded-bl, rounded-br (简写: rd-tl, rd-tr, rd-bl, rd-br)
     [new RegExp(`^${p}(?:rounded|rd)-tl(?:-(.+))?$`), ([_, s]: [any, any], { theme }: any) => {
-      const v = (theme[themeKey] as any)?.[s || 'DEFAULT']
+      const v = (theme[themeKey] as any)?.[resolveThemeTokenKey(s || 'DEFAULT', themeTokenPrefix)]
       if (v)
         return { 'border-top-left-radius': v }
     }],
     [new RegExp(`^${p}(?:rounded|rd)-tr(?:-(.+))?$`), ([_, s]: [any, any], { theme }: any) => {
-      const v = (theme[themeKey] as any)?.[s || 'DEFAULT']
+      const v = (theme[themeKey] as any)?.[resolveThemeTokenKey(s || 'DEFAULT', themeTokenPrefix)]
       if (v)
         return { 'border-top-right-radius': v }
     }],
     [new RegExp(`^${p}(?:rounded|rd)-bl(?:-(.+))?$`), ([_, s]: [any, any], { theme }: any) => {
-      const v = (theme[themeKey] as any)?.[s || 'DEFAULT']
+      const v = (theme[themeKey] as any)?.[resolveThemeTokenKey(s || 'DEFAULT', themeTokenPrefix)]
       if (v)
         return { 'border-bottom-left-radius': v }
     }],
     [new RegExp(`^${p}(?:rounded|rd)-br(?:-(.+))?$`), ([_, s]: [any, any], { theme }: any) => {
-      const v = (theme[themeKey] as any)?.[s || 'DEFAULT']
+      const v = (theme[themeKey] as any)?.[resolveThemeTokenKey(s || 'DEFAULT', themeTokenPrefix)]
       if (v)
         return { 'border-bottom-right-radius': v }
     }],
     // 边侧圆角: rounded-t, rounded-r, rounded-b, rounded-l (简写: rd-t, rd-r, rd-b, rd-l)
     [new RegExp(`^${p}(?:rounded|rd)-t(?:-(.+))?$`), ([_, s]: [any, any], { theme }: any) => {
-      const v = (theme[themeKey] as any)?.[s || 'DEFAULT']
+      const v = (theme[themeKey] as any)?.[resolveThemeTokenKey(s || 'DEFAULT', themeTokenPrefix)]
       if (v)
         return { 'border-top-left-radius': v, 'border-top-right-radius': v }
     }],
     [new RegExp(`^${p}(?:rounded|rd)-r(?:-(.+))?$`), ([_, s]: [any, any], { theme }: any) => {
-      const v = (theme[themeKey] as any)?.[s || 'DEFAULT']
+      const v = (theme[themeKey] as any)?.[resolveThemeTokenKey(s || 'DEFAULT', themeTokenPrefix)]
       if (v)
         return { 'border-top-right-radius': v, 'border-bottom-right-radius': v }
     }],
     [new RegExp(`^${p}(?:rounded|rd)-b(?:-(.+))?$`), ([_, s]: [any, any], { theme }: any) => {
-      const v = (theme[themeKey] as any)?.[s || 'DEFAULT']
+      const v = (theme[themeKey] as any)?.[resolveThemeTokenKey(s || 'DEFAULT', themeTokenPrefix)]
       if (v)
         return { 'border-bottom-left-radius': v, 'border-bottom-right-radius': v }
     }],
     [new RegExp(`^${p}(?:rounded|rd)-l(?:-(.+))?$`), ([_, s]: [any, any], { theme }: any) => {
-      const v = (theme[themeKey] as any)?.[s || 'DEFAULT']
+      const v = (theme[themeKey] as any)?.[resolveThemeTokenKey(s || 'DEFAULT', themeTokenPrefix)]
       if (v)
         return { 'border-top-left-radius': v, 'border-bottom-left-radius': v }
     }],
@@ -248,7 +256,7 @@ export function createRoundedRules(prefix: string, themeKey: 'borderRadius' | 'r
  * @param prefix class 前缀
  * @param themeKey 主题键名，'boxShadow' 或 'shadow'
  */
-export function createShadowRules(prefix: string, themeKey: 'boxShadow' | 'shadow' = 'boxShadow') {
+export function createShadowRules(prefix: string, themeKey: 'boxShadow' | 'shadow' = 'boxShadow', themeTokenPrefix?: string) {
   const p = prefix ? `${prefix}-` : ''
   
   return [
@@ -256,7 +264,7 @@ export function createShadowRules(prefix: string, themeKey: 'boxShadow' | 'shado
       new RegExp(`^${p}shadow(?:-(.+))?$`),
       ([_, s]: [any, any], { theme }: any) => {
         // 如果 s 存在(有后缀)，用 s；如果 s 不存在(没后缀)，用 'DEFAULT'
-        const key = s || 'DEFAULT'
+        const key = resolveThemeTokenKey(s || 'DEFAULT', themeTokenPrefix)
         const v = (theme[themeKey] as any)?.[key]
 
         if (v)

--- a/packages/unocss/src/common/theme.ts
+++ b/packages/unocss/src/common/theme.ts
@@ -2,6 +2,15 @@
  * 主题配置生成函数
  */
 
+export function withThemeTokenPrefix<T>(theme: Record<string, T>, tokenPrefix: string | undefined) {
+  if (!tokenPrefix)
+    return theme
+
+  return Object.fromEntries(
+    Object.entries(theme).map(([key, value]) => [`${tokenPrefix}-${key}`, value]),
+  ) as Record<string, T>
+}
+
 /**
  * 构建颜色主题
  */

--- a/packages/unocss/src/preset.test.ts
+++ b/packages/unocss/src/preset.test.ts
@@ -33,10 +33,13 @@ describe('presetAntd', () => {
 
   it('can disable unprefixed utilities', () => {
     const preset = presetAntd({ allowUnprefixed: false })
+    const colors = (preset.theme as { colors?: Record<string, string> })?.colors
 
     expect(hasMatchingRule(preset.rules as any[], 'a-color-primary')).toBe(true)
     expect(hasMatchingRule(preset.rules as any[], 'color-primary')).toBe(false)
     expect(hasUnprefixedAutocomplete(preset.autocomplete?.templates as string[])).toBe(false)
+    expect(colors?.primary).toBeUndefined()
+    expect(colors?.['a-primary']).toBeDefined()
   })
 })
 
@@ -50,9 +53,12 @@ describe('presetAntdTailwind4', () => {
 
   it('can disable unprefixed utilities', () => {
     const preset = presetAntdTailwind4({ allowUnprefixed: false })
+    const colors = (preset.theme as { colors?: Record<string, string> })?.colors
 
     expect(hasMatchingRule(preset.rules as any[], 'a-color-primary')).toBe(true)
     expect(hasMatchingRule(preset.rules as any[], 'color-primary')).toBe(false)
     expect(hasUnprefixedAutocomplete(preset.autocomplete?.templates as string[])).toBe(false)
+    expect(colors?.primary).toBeUndefined()
+    expect(colors?.['a-primary']).toBeDefined()
   })
 })

--- a/packages/unocss/src/preset.ts
+++ b/packages/unocss/src/preset.ts
@@ -7,6 +7,7 @@ import {
   buildFontSizeTheme,
   buildPalettes,
   buildShadowTheme,
+  withThemeTokenPrefix,
   createAutocompleteTemplates,
   createBorderRules,
   createColorRules,
@@ -24,6 +25,7 @@ export const presetAntd = definePreset((options?: AntdPresetOptions): Preset => 
   const prefix = options?.prefix || 'a'
   const allowUnprefixed = options?.allowUnprefixed ?? true
   const antPrefix = options?.antPrefix || 'ant'
+  const themeTokenPrefix = allowUnprefixed ? undefined : prefix
 
   // 根据 antPrefix 动态生成调色板
   const builtPalettes = buildPalettes(antPrefix)
@@ -31,21 +33,21 @@ export const presetAntd = definePreset((options?: AntdPresetOptions): Preset => 
   return {
     name: 'preset-antd',
     theme: {
-      colors: buildColorsTheme(antPrefix, builtPalettes),
-      borderRadius: buildBorderRadiusTheme(antPrefix),
-      fontSize: buildFontSizeTheme(antPrefix),
-      boxShadow: buildShadowTheme(antPrefix),
+      colors: withThemeTokenPrefix(buildColorsTheme(antPrefix, builtPalettes), themeTokenPrefix),
+      borderRadius: withThemeTokenPrefix(buildBorderRadiusTheme(antPrefix), themeTokenPrefix),
+      fontSize: withThemeTokenPrefix(buildFontSizeTheme(antPrefix), themeTokenPrefix),
+      boxShadow: withThemeTokenPrefix(buildShadowTheme(antPrefix), themeTokenPrefix),
     },
 
     // 自定义规则
     rules: ([
       // 带前缀的规则 (如 a-mx-lg)
-      ...createColorRules(prefix),
-      ...createBorderRules(prefix),
+      ...createColorRules(prefix, themeTokenPrefix),
+      ...createBorderRules(prefix, themeTokenPrefix),
       ...createSpacingRules(prefix, antPrefix),
-      ...createTextRules(prefix, 'fontSize'),
-      ...createRoundedRules(prefix, 'borderRadius'),
-      ...createShadowRules(prefix, 'boxShadow'),
+      ...createTextRules(prefix, 'fontSize', themeTokenPrefix),
+      ...createRoundedRules(prefix, 'borderRadius', themeTokenPrefix),
+      ...createShadowRules(prefix, 'boxShadow', themeTokenPrefix),
       // 可选的不带前缀规则 (如 mx-lg)
       ...(allowUnprefixed
         ? [

--- a/packages/unocss/src/presetTailwind4.ts
+++ b/packages/unocss/src/presetTailwind4.ts
@@ -7,6 +7,7 @@ import {
   buildRadiusTheme,
   buildShadowTheme,
   buildTextTheme,
+  withThemeTokenPrefix,
   createAutocompleteTemplates,
   createBorderRules,
   createColorRules,
@@ -24,6 +25,7 @@ export const presetAntdTailwind4 = definePreset((options?: AntdPresetTailwind4Op
   const prefix = options?.prefix || 'a'
   const allowUnprefixed = options?.allowUnprefixed ?? true
   const antPrefix = options?.antPrefix || 'ant'
+  const themeTokenPrefix = allowUnprefixed ? undefined : prefix
 
   // 根据 antPrefix 动态生成调色板
   const builtPalettes = buildPalettes(antPrefix)
@@ -31,10 +33,10 @@ export const presetAntdTailwind4 = definePreset((options?: AntdPresetTailwind4Op
   return {
     name: 'preset-antd-tailwind4',
     theme: {
-      colors: buildColorsTheme(antPrefix, builtPalettes),
-      radius: buildRadiusTheme(antPrefix),
-      text: buildTextTheme(antPrefix),
-      shadow: buildShadowTheme(antPrefix),
+      colors: withThemeTokenPrefix(buildColorsTheme(antPrefix, builtPalettes), themeTokenPrefix),
+      radius: withThemeTokenPrefix(buildRadiusTheme(antPrefix), themeTokenPrefix),
+      text: withThemeTokenPrefix(buildTextTheme(antPrefix), themeTokenPrefix),
+      shadow: withThemeTokenPrefix(buildShadowTheme(antPrefix), themeTokenPrefix),
       // Tailwind 4 新增的 defaults 配置
       defaults: {},
     },
@@ -42,12 +44,12 @@ export const presetAntdTailwind4 = definePreset((options?: AntdPresetTailwind4Op
     // 自定义规则
     rules: ([
       // 带前缀的规则 (如 a-mx-lg)
-      ...createColorRules(prefix),
-      ...createBorderRules(prefix),
+      ...createColorRules(prefix, themeTokenPrefix),
+      ...createBorderRules(prefix, themeTokenPrefix),
       ...createSpacingRules(prefix, antPrefix),
-      ...createTextRules(prefix, 'text'),
-      ...createRoundedRules(prefix, 'radius'),
-      ...createShadowRules(prefix, 'shadow'),
+      ...createTextRules(prefix, 'text', themeTokenPrefix),
+      ...createRoundedRules(prefix, 'radius', themeTokenPrefix),
+      ...createShadowRules(prefix, 'shadow', themeTokenPrefix),
       // 可选的不带前缀规则 (如 mx-lg)
       ...(allowUnprefixed
         ? [


### PR DESCRIPTION

## 修复内容

当设置 `allowUnprefixed: false` 时，确保：
1. 只暴露带前缀的工具类（如 `a-bg-primary`）
2. 主题 token 也只暴露带前缀的键名（如 `colors['a-primary']`）
3. 规则正确解析带前缀的主题 token

## 变更详情

- 新增 `withThemeTokenPrefix` 函数，在 `allowUnprefixed: false` 时给主题键添加前缀
- 新增 `resolveThemeTokenKey` 辅助函数，用于规则中正确解析主题 token
- 更新所有规则创建函数，支持传递 `themeTokenPrefix` 参数
- 更新 `presetAntd` 和 `presetAntdTailwind4` 以正确处理主题 token 前缀

## 测试方案

已添加单元测试验证：
- 默认情况下支持无前缀工具类
- 当 `allowUnprefixed: false` 时：
  - 只存在带前缀的规则（`a-color-primary`）
  - 不存在无前缀的规则（`color-primary`）
  - 自动补全模板不包含无前缀项
  - 主题 `colors.primary` 未定义
  - 主题 `colors['a-primary']` 已定义
