### PR TITLE
fix: remove white color override to prevent pollution of built-in white

### DIFF
--- a/packages/tailwind/src/theme.ts
+++ b/packages/tailwind/src/theme.ts
@@ -49,7 +49,6 @@ export function buildColorsTheme(antPrefix: string, builtPalettes: Record<string
     'text-quaternary': `var(--${antPrefix}-color-text-quaternary)`,
 
     // 中性色
-    'white': `var(--${antPrefix}-color-white)`,
     'base': `var(--${antPrefix}-color-bg-base)`,
     'container': `var(--${antPrefix}-color-bg-container)`,
     'layout': `var(--${antPrefix}-color-bg-layout)`,

--- a/packages/tailwind/src/v4.ts
+++ b/packages/tailwind/src/v4.ts
@@ -134,7 +134,6 @@ export function generateThemeCSS(options: AntdPluginOptions = {}): string {
 
   lines.push('')
   lines.push('  /* Background Colors */')
-  lines.push(`  --color-white: var(--${antPrefix}-color-white);`)
   lines.push(`  --color-base: var(--${antPrefix}-color-bg-base);`)
   lines.push(`  --color-container: var(--${antPrefix}-color-bg-container);`)
   lines.push(`  --color-layout: var(--${antPrefix}-color-bg-layout);`)

--- a/packages/tailwind/theme.css
+++ b/packages/tailwind/theme.css
@@ -203,7 +203,6 @@
   --color-quat: var(--ant-color-text-quaternary);
 
   /* Background Colors */
-  --color-white: var(--ant-color-white);
   --color-base: var(--ant-color-bg-base);
   --color-container: var(--ant-color-bg-container);
   --color-layout: var(--ant-color-bg-layout);

--- a/packages/unocss/src/common/theme.ts
+++ b/packages/unocss/src/common/theme.ts
@@ -62,9 +62,6 @@ export function buildColorsTheme(antPrefix: string, builtPalettes: Record<string
     'text-quat': `var(--${antPrefix}-color-text-quaternary)`,
     'text-quaternary': `var(--${antPrefix}-color-text-quaternary)`,
 
-    // 4. 中性色 (背景与文字 - 保持之前简化后的 Key)
-    'white': `var(--${antPrefix}-color-white)`,
-
     // 背景 (Background)
     'base': `var(--${antPrefix}-color-bg-base)`,
     'container': `var(--${antPrefix}-color-bg-container)`, // 常用：白色卡片背景


### PR DESCRIPTION
fixed #2

## Problem

The plugin was mapping the `white` color key to `var(--ant-color-white)` in both Tailwind (v3/v4) and UnoCSS presets. This caused two issues:

1. **`text-white` broken**: The CSS variable `--ant-color-white` may not always be injected, so the color falls back to nothing instead of `#fff`.
2. **`text-white/10` broken**: In Tailwind v3, opacity modifiers require the color to be expressible as RGB channels. A raw CSS variable cannot be decomposed, so the modifier silently fails.

## Fix

Remove the `white` entry from `buildColorsTheme` in all three locations:

- `packages/tailwind/src/theme.ts` (Tailwind v3 plugin)
- `packages/tailwind/src/v4.ts` (Tailwind v4 `@theme` generator)
- `packages/unocss/src/common/theme.ts` (UnoCSS preset)

With the override removed, Tailwind and UnoCSS fall back to their own built-in `white = #fff`, which works correctly with both direct usage (`text-white`) and opacity modifiers (`text-white/10`).