### PR TITLE
feat: add color-fill variants to text and background colors

### DIFF
--- a/packages/tailwind/src/theme.ts
+++ b/packages/tailwind/src/theme.ts
@@ -48,6 +48,12 @@ export function buildColorsTheme(antPrefix: string, builtPalettes: Record<string
     'text-quat': `var(--${antPrefix}-color-text-quaternary)`,
     'text-quaternary': `var(--${antPrefix}-color-text-quaternary)`,
 
+    // 填充色
+    'fill': `var(--${antPrefix}-color-fill)`,
+    'fill-secondary': `var(--${antPrefix}-color-fill-secondary)`,
+    'fill-tertiary': `var(--${antPrefix}-color-fill-tertiary)`,
+    'fill-quaternary': `var(--${antPrefix}-color-fill-quaternary)`,
+
     // 中性色
     'base': `var(--${antPrefix}-color-bg-base)`,
     'container': `var(--${antPrefix}-color-bg-container)`,

--- a/packages/tailwind/src/v4.ts
+++ b/packages/tailwind/src/v4.ts
@@ -131,6 +131,10 @@ export function generateThemeCSS(options: AntdPluginOptions = {}): string {
   lines.push(`  --color-main: var(--${antPrefix}-color-text);`)
   lines.push(`  --color-sec: var(--${antPrefix}-color-text-secondary);`)
   lines.push(`  --color-quat: var(--${antPrefix}-color-text-quaternary);`)
+  lines.push(`  --color-fill: var(--${antPrefix}-color-fill);`)
+  lines.push(`  --color-fill-secondary: var(--${antPrefix}-color-fill-secondary);`)
+  lines.push(`  --color-fill-tertiary: var(--${antPrefix}-color-fill-tertiary);`)
+  lines.push(`  --color-fill-quaternary: var(--${antPrefix}-color-fill-quaternary);`)
 
   lines.push('')
   lines.push('  /* Background Colors */')

--- a/packages/unocss/src/common/autocomplete.ts
+++ b/packages/unocss/src/common/autocomplete.ts
@@ -26,7 +26,7 @@ function buildColorPaletteEnum() {
 
 // 固定的 AntD 主题枚举值（避免污染 $spacing/$colors 等全局 token）
 const SPACING_ENUM = '(xxs|xs|sm|md|lg|xl|xxl|xxxl)'
-const SEMANTIC_COLORS = 'primary|primary-hover|primary-active|primary-bg|primary-bg-hover|success|success-bg|success-border|success-hover|warning|warning-bg|warning-border|warning-hover|error|error-bg|error-border|error-hover|info|info-bg|info-border|link|link-hover|link-active|text|text-secondary|text-tertiary|text-quat|text-quaternary|white|base|container|layout|elevated|mask|main|sec|quat|split|border|border-sec'
+const SEMANTIC_COLORS = 'primary|primary-hover|primary-active|primary-bg|primary-bg-hover|success|success-bg|success-border|success-hover|warning|warning-bg|warning-border|warning-hover|error|error-bg|error-border|error-hover|info|info-bg|info-border|link|link-hover|link-active|text|text-secondary|text-tertiary|text-quat|text-quaternary|fill|fill-secondary|fill-tertiary|fill-quaternary|white|base|container|layout|elevated|mask|main|sec|quat|split|border|border-sec'
 const COLOR_ENUM = `(${buildColorPaletteEnum()}|${SEMANTIC_COLORS})`
 const RADIUS_ENUM = '(xs|sm|lg)'
 const FONT_ENUM = '(sm|lg|xl|h1|h2|h3)'

--- a/packages/unocss/src/common/theme.ts
+++ b/packages/unocss/src/common/theme.ts
@@ -62,6 +62,12 @@ export function buildColorsTheme(antPrefix: string, builtPalettes: Record<string
     'text-quat': `var(--${antPrefix}-color-text-quaternary)`,
     'text-quaternary': `var(--${antPrefix}-color-text-quaternary)`,
 
+    // 填充色
+    'fill': `var(--${antPrefix}-color-fill)`,
+    'fill-secondary': `var(--${antPrefix}-color-fill-secondary)`,
+    'fill-tertiary': `var(--${antPrefix}-color-fill-tertiary)`,
+    'fill-quaternary': `var(--${antPrefix}-color-fill-quaternary)`,
+
     // 背景 (Background)
     'base': `var(--${antPrefix}-color-bg-base)`,
     'container': `var(--${antPrefix}-color-bg-container)`, // 常用：白色卡片背景


### PR DESCRIPTION
Adds `--ant-color-fill`, `--ant-color-fill-secondary`, `--ant-color-fill-tertiary`, and `--ant-color-fill-quaternary` as usable color tokens for both text and background utility classes.

## Changes

- **`tailwind/src/theme.ts` & `unocss/src/common/theme.ts`** — added `fill`, `fill-secondary`, `fill-tertiary`, `fill-quaternary` entries to `buildColorsTheme`, enabling use with `text-*` and `bg-*` utilities
- **`tailwind/src/v4.ts`** — added corresponding `--color-fill-*` variables to the `@theme` CSS output for Tailwind v4
- **`unocss/src/common/autocomplete.ts`** — added fill tokens to `SEMANTIC_COLORS` for IDE autocomplete

## Usage

```html
<!-- Text color -->
<span class="text-fill">...</span>
<span class="text-fill-secondary">...</span>

<!-- Background color -->
<div class="bg-fill-tertiary">...</div>
<div class="bg-fill-quaternary">...</div>
```