### PR TITLE
fix(unocss): remove bare `border`/`b` rule that hijacks UnoCSS default border-width behavior

### DIFF
--- a/packages/unocss/src/common/autocomplete.ts
+++ b/packages/unocss/src/common/autocomplete.ts
@@ -47,8 +47,6 @@ function createTemplatesForPrefix(prefix: string, themeKeys: AutocompleteOptions
     `${p}bg-${COLOR_ENUM}`,
 
     // Border 边框色
-    `${p}border`,
-    `${p}b`,
     `${p}border-${COLOR_ENUM}`,
     `${p}b-${COLOR_ENUM}`,
     // Border 方向性

--- a/packages/unocss/src/common/rules.ts
+++ b/packages/unocss/src/common/rules.ts
@@ -39,12 +39,6 @@ export function createBorderRules(prefix: string, themeTokenPrefix?: string) {
   const p = prefix ? `${prefix}-` : ''
   
   return [
-    // ${prefix}-border 或 ${prefix}-b -> border-color: var(--${antPrefix}-color-border) (DEFAULT)
-    [new RegExp(`^${p}(?:border|b)$`), (_: any, { theme }: any) => {
-      const color = (theme.colors as any)?.[resolveThemeTokenKey('border', themeTokenPrefix)]
-      if (color)
-        return { 'border-color': color }
-    }],
     // ${prefix}-border-primary 或 ${prefix}-b-primary -> border-color: ...
     [new RegExp(`^${p}(?:border|b)-(.+)$`), ([_, c]: [any, any], { theme }: any) => {
       const color = (theme.colors as any)?.[resolveThemeTokenKey(c!, themeTokenPrefix)]


### PR DESCRIPTION
The `createBorderRules` function included a bare `^(?:border|b)$` rule that, when `allowUnprefixed: true` (the default), would intercept UnoCSS's native `border` class and return `border-color` instead of the expected `border-width: 1px`.

## Changes

- **`packages/unocss/src/common/rules.ts`** — Removed the no-suffix rule from `createBorderRules`. Color-suffixed variants (`border-primary`, `a-border-sec`, directional `border-t-*`, etc.) are untouched.
- **`packages/unocss/src/common/autocomplete.ts`** — Removed the corresponding bare `${p}border` / `${p}b` autocomplete entries.

**Tailwind** — No changes needed; both v3 (`theme.extend.colors`) and v4 (`--color-border` CSS var) only add tokens to the theme and never override the `border` utility itself.

### Before

```ts
// bare `border` or `b` class → { 'border-color': 'var(--ant-color-border)' }
// overrides UnoCSS built-in `border` → border-width: 1px
```

### After

```ts
// `border` / `b` → UnoCSS default (border-width: 1px) ✓
// `border-primary` / `a-border-primary` → { 'border-color': 'var(--ant-color-primary)' } ✓
```