### PR TITLE
feat: use `ant-*` prefixed keys for font-size tokens to avoid colliding with built-in rem scale

### DIFF
--- a/packages/tailwind/README.md
+++ b/packages/tailwind/README.md
@@ -52,7 +52,7 @@ const customCss = generateThemeCSS({ antPrefix: 'my-app' })
 ```vue
 <template>
   <div class="bg-primary text-white p-lg rounded-lg shadow-card">
-    <h1 class="text-h1 text-primary">Hello Ant Design Vue</h1>
+    <h1 class="text-ant-h1 text-primary">Hello Ant Design Vue</h1>
     <p class="text-text-secondary mt-sm">
       使用 Tailwind CSS v4 工具类
     </p>
@@ -96,7 +96,7 @@ export default {
 ```vue
 <template>
   <div class="bg-primary text-white p-lg rounded-lg shadow-card">
-    <h1 class="text-h1 text-primary">Hello Ant Design Vue</h1>
+    <h1 class="text-ant-h1 text-primary">Hello Ant Design Vue</h1>
     <p class="text-secondary mt-sm">
       使用 Tailwind CSS 工具类和 Ant Design Vue 设计系统
     </p>
@@ -169,13 +169,13 @@ export default {
 ### Typography
 
 ```html
-<div class="text-sm">Small text</div>
-<div class="text">Default text</div>
-<div class="text-lg">Large text</div>
-<div class="text-xl">Extra large text</div>
-<div class="text-h1">Heading 1</div>
-<div class="text-h2">Heading 2</div>
-<div class="text-h3">Heading 3</div>
+<div class="text-ant-sm">Small text</div>
+<div class="text-ant-base">Default text</div>
+<div class="text-ant-lg">Large text</div>
+<div class="text-ant-xl">Extra large text</div>
+<div class="text-ant-h1">Heading 1</div>
+<div class="text-ant-h2">Heading 2</div>
+<div class="text-ant-h3">Heading 3</div>
 ```
 
 ### Shadows

--- a/packages/tailwind/README.zh-CN.md
+++ b/packages/tailwind/README.zh-CN.md
@@ -61,7 +61,7 @@ Tailwind v4 的主题变量命名约定：
 | `--padding-*` | `p-lg`, `px-sm` | `--ant-padding-*` |
 | `--margin-*` | `m-lg`, `my-sm` | `--ant-margin-*` |
 | `--radius-*` | `rounded-lg` | `--ant-border-radius-*` |
-| `--text-*` | `text-h1` | `--ant-font-size-*` |
+| `--text-ant-*` | `text-ant-h1`, `text-ant-sm` | `--ant-font-size-*` |
 | `--shadow-*` | `shadow-card` | `--ant-box-shadow-*` |
 
 ### Tailwind v4 使用示例
@@ -69,7 +69,7 @@ Tailwind v4 的主题变量命名约定：
 ```vue
 <template>
   <div class="bg-primary text-white p-lg rounded-lg shadow-card">
-    <h1 class="text-h1 text-primary">你好 Ant Design Vue</h1>
+    <h1 class="text-ant-h1 text-primary">你好 Ant Design Vue</h1>
     <p class="text-text-secondary mt-sm">
       使用 Tailwind CSS v4 工具类
     </p>
@@ -118,7 +118,7 @@ export default {
 ```vue
 <template>
   <div class="bg-primary text-white p-lg rounded-lg shadow-card">
-    <h1 class="text-h1 text-primary">你好 Ant Design Vue</h1>
+    <h1 class="text-ant-h1 text-primary">你好 Ant Design Vue</h1>
     <p class="text-secondary mt-sm">
       使用 Tailwind CSS 工具类和 Ant Design Vue 设计系统
     </p>
@@ -194,13 +194,13 @@ export default {
 ### 字体
 
 ```html
-<div class="text-sm">小号文本</div>
-<div class="text">默认文本</div>
-<div class="text-lg">大号文本</div>
-<div class="text-xl">超大号文本</div>
-<div class="text-h1">一级标题</div>
-<div class="text-h2">二级标题</div>
-<div class="text-h3">三级标题</div>
+<div class="text-ant-sm">小号文本</div>
+<div class="text-ant-base">默认文本</div>
+<div class="text-ant-lg">大号文本</div>
+<div class="text-ant-xl">超大号文本</div>
+<div class="text-ant-h1">一级标题</div>
+<div class="text-ant-h2">二级标题</div>
+<div class="text-ant-h3">三级标题</div>
 ```
 
 ### 阴影

--- a/packages/tailwind/src/theme.ts
+++ b/packages/tailwind/src/theme.ts
@@ -102,16 +102,20 @@ export function buildBorderRadiusTheme(antPrefix: string) {
 
 /**
  * 构建字体大小主题（fontSize）
+ *
+ * 键名使用 `ant-*` 前缀，避免与 Tailwind 内置的 rem 体系冲突
+ * （例如内置的 text-sm → 0.875rem 不会被覆盖）。
+ * 用法：`text-ant-sm`、`text-ant-lg` 等。
  */
 export function buildFontSizeTheme(antPrefix: string) {
   return {
-    sm: `var(--${antPrefix}-font-size-sm)`,
-    DEFAULT: `var(--${antPrefix}-font-size)`,
-    lg: `var(--${antPrefix}-font-size-lg)`,
-    xl: `var(--${antPrefix}-font-size-xl)`,
-    h1: `var(--${antPrefix}-font-size-heading-1)`,
-    h2: `var(--${antPrefix}-font-size-heading-2)`,
-    h3: `var(--${antPrefix}-font-size-heading-3)`,
+    'ant-sm': `var(--${antPrefix}-font-size-sm)`,
+    'ant-base': `var(--${antPrefix}-font-size)`,
+    'ant-lg': `var(--${antPrefix}-font-size-lg)`,
+    'ant-xl': `var(--${antPrefix}-font-size-xl)`,
+    'ant-h1': `var(--${antPrefix}-font-size-heading-1)`,
+    'ant-h2': `var(--${antPrefix}-font-size-heading-2)`,
+    'ant-h3': `var(--${antPrefix}-font-size-heading-3)`,
   }
 }
 

--- a/packages/tailwind/src/v4.ts
+++ b/packages/tailwind/src/v4.ts
@@ -175,13 +175,13 @@ export function generateThemeCSS(options: AntdPluginOptions = {}): string {
   // 字体大小变量 --text-*
   lines.push('')
   lines.push('  /* Font Size */')
-  lines.push(`  --text-sm: var(--${antPrefix}-font-size-sm);`)
-  lines.push(`  --text-DEFAULT: var(--${antPrefix}-font-size);`)
-  lines.push(`  --text-lg: var(--${antPrefix}-font-size-lg);`)
-  lines.push(`  --text-xl: var(--${antPrefix}-font-size-xl);`)
-  lines.push(`  --text-h1: var(--${antPrefix}-font-size-heading-1);`)
-  lines.push(`  --text-h2: var(--${antPrefix}-font-size-heading-2);`)
-  lines.push(`  --text-h3: var(--${antPrefix}-font-size-heading-3);`)
+  lines.push(`  --text-ant-sm: var(--${antPrefix}-font-size-sm);`)
+  lines.push(`  --text-ant-base: var(--${antPrefix}-font-size);`)
+  lines.push(`  --text-ant-lg: var(--${antPrefix}-font-size-lg);`)
+  lines.push(`  --text-ant-xl: var(--${antPrefix}-font-size-xl);`)
+  lines.push(`  --text-ant-h1: var(--${antPrefix}-font-size-heading-1);`)
+  lines.push(`  --text-ant-h2: var(--${antPrefix}-font-size-heading-2);`)
+  lines.push(`  --text-ant-h3: var(--${antPrefix}-font-size-heading-3);`)
 
   // 阴影变量 --shadow-*
   lines.push('')

--- a/packages/tailwind/theme.css
+++ b/packages/tailwind/theme.css
@@ -201,6 +201,10 @@
   --color-main: var(--ant-color-text);
   --color-sec: var(--ant-color-text-secondary);
   --color-quat: var(--ant-color-text-quaternary);
+  --color-fill: var(--ant-color-fill);
+  --color-fill-secondary: var(--ant-color-fill-secondary);
+  --color-fill-tertiary: var(--ant-color-fill-tertiary);
+  --color-fill-quaternary: var(--ant-color-fill-quaternary);
 
   /* Background Colors */
   --color-base: var(--ant-color-bg-base);
@@ -242,13 +246,13 @@
   --radius-lg: var(--ant-border-radius-lg);
 
   /* Font Size */
-  --text-sm: var(--ant-font-size-sm);
-  --text-DEFAULT: var(--ant-font-size);
-  --text-lg: var(--ant-font-size-lg);
-  --text-xl: var(--ant-font-size-xl);
-  --text-h1: var(--ant-font-size-heading-1);
-  --text-h2: var(--ant-font-size-heading-2);
-  --text-h3: var(--ant-font-size-heading-3);
+  --text-ant-sm: var(--ant-font-size-sm);
+  --text-ant-base: var(--ant-font-size);
+  --text-ant-lg: var(--ant-font-size-lg);
+  --text-ant-xl: var(--ant-font-size-xl);
+  --text-ant-h1: var(--ant-font-size-heading-1);
+  --text-ant-h2: var(--ant-font-size-heading-2);
+  --text-ant-h3: var(--ant-font-size-heading-3);
 
   /* Box Shadow */
   --shadow-DEFAULT: var(--ant-box-shadow);

--- a/packages/unocss/README.md
+++ b/packages/unocss/README.md
@@ -98,7 +98,7 @@ Both presets support the same utility class patterns:
   <div class="a-shadow-card">Card Shadow</div>
 
   <!-- Text -->
-  <div class="a-text-lg a-color-primary">Large Text</div>
+  <div class="a-text-ant-lg a-color-primary">Large Text</div>
 </template>
 ```
 
@@ -144,7 +144,10 @@ Both presets support the same utility class patterns:
 - `a-shadow-{type}` - Specific shadow type (card, drawer-r, etc.)
 
 ### Text Utilities
-- `a-text-{size}` - Font size (sm, lg, xl, h1, h2, h3)
+- `a-text-ant-{size}` - Font size mapped to Ant Design CSS variables (ant-sm, ant-base, ant-lg, ant-xl, ant-h1, ant-h2, ant-h3)
+
+> **Note:** Font-size keys use the `ant-*` prefix (e.g. `text-ant-sm`, `a-text-ant-lg`) to avoid overriding
+> the built-in UnoCSS/Tailwind rem-based scale (e.g. `text-sm → 0.875rem`). Both systems coexist without conflict.
 
 ## Available Theme Tokens
 
@@ -165,6 +168,9 @@ Both presets support the same utility class patterns:
 
 ### Shadow / BoxShadow
 `sec`/`secondary`, `ter`/`tertiary`, `card`, `arrow`, `drawer-r`, `drawer-l`, `drawer-u`, `drawer-d`
+
+### Font Size / Text
+`ant-sm`, `ant-base`, `ant-lg`, `ant-xl`, `ant-h1`, `ant-h2`, `ant-h3`
 
 ## License
 

--- a/packages/unocss/src/common/autocomplete.ts
+++ b/packages/unocss/src/common/autocomplete.ts
@@ -29,8 +29,8 @@ const SPACING_ENUM = '(xxs|xs|sm|md|lg|xl|xxl|xxxl)'
 const SEMANTIC_COLORS = 'primary|primary-hover|primary-active|primary-bg|primary-bg-hover|success|success-bg|success-border|success-hover|warning|warning-bg|warning-border|warning-hover|error|error-bg|error-border|error-hover|info|info-bg|info-border|link|link-hover|link-active|text|text-secondary|text-tertiary|text-quat|text-quaternary|fill|fill-secondary|fill-tertiary|fill-quaternary|white|base|container|layout|elevated|mask|main|sec|quat|split|border|border-sec'
 const COLOR_ENUM = `(${buildColorPaletteEnum()}|${SEMANTIC_COLORS})`
 const RADIUS_ENUM = '(xs|sm|lg)'
-const FONT_ENUM = '(sm|lg|xl|h1|h2|h3)'
-const TEXT_ENUM = '(sm|lg|xl|h1|h2|h3)'
+const FONT_ENUM = '(ant-sm|ant-base|ant-lg|ant-xl|ant-h1|ant-h2|ant-h3)'
+const TEXT_ENUM = '(ant-sm|ant-base|ant-lg|ant-xl|ant-h1|ant-h2|ant-h3)'
 const SHADOW_ENUM = '(sec|secondary|ter|tertiary|card|arrow|drawer-r|drawer-l|drawer-u|drawer-d|drawer-right|drawer-left|drawer-up|drawer-down)'
 
 /**

--- a/packages/unocss/src/common/theme.ts
+++ b/packages/unocss/src/common/theme.ts
@@ -126,43 +126,50 @@ export function buildRadiusTheme(antPrefix: string) {
 
 /**
  * 构建字体大小主题（Wind3 风格）
+ *
+ * 键名使用 `ant-*` 前缀，避免与 UnoCSS/Tailwind 内置的 rem 体系冲突
+ * （例如内置的 text-sm → 0.875rem 不会被覆盖）。
+ * 用法：`a-text-ant-sm`（带前缀）或 `text-ant-sm`（allowUnprefixed: true）。
  */
 export function buildFontSizeTheme(antPrefix: string) {
   return {
-    sm: `var(--${antPrefix}-font-size-sm)`,
-    DEFAULT: `var(--${antPrefix}-font-size)`,
-    lg: `var(--${antPrefix}-font-size-lg)`,
-    xl: `var(--${antPrefix}-font-size-xl)`,
-    h1: `var(--${antPrefix}-font-size-heading-1)`,
-    h2: `var(--${antPrefix}-font-size-heading-2)`,
-    h3: `var(--${antPrefix}-font-size-heading-3)`,
+    'ant-sm': `var(--${antPrefix}-font-size-sm)`,
+    'ant-base': `var(--${antPrefix}-font-size)`,
+    'ant-lg': `var(--${antPrefix}-font-size-lg)`,
+    'ant-xl': `var(--${antPrefix}-font-size-xl)`,
+    'ant-h1': `var(--${antPrefix}-font-size-heading-1)`,
+    'ant-h2': `var(--${antPrefix}-font-size-heading-2)`,
+    'ant-h3': `var(--${antPrefix}-font-size-heading-3)`,
   }
 }
 
 /**
  * 构建文本主题（Tailwind 4 风格 - text）
+ *
+ * 键名使用 `ant-*` 前缀，避免与 UnoCSS/Tailwind 内置的 rem 体系冲突。
+ * 用法：`a-text-ant-sm`（带前缀）或 `text-ant-sm`（allowUnprefixed: true）。
  */
 export function buildTextTheme(antPrefix: string) {
   return {
-    sm: {
+    'ant-sm': {
       fontSize: `var(--${antPrefix}-font-size-sm)`,
     },
-    DEFAULT: {
+    'ant-base': {
       fontSize: `var(--${antPrefix}-font-size)`,
     },
-    lg: {
+    'ant-lg': {
       fontSize: `var(--${antPrefix}-font-size-lg)`,
     },
-    xl: {
+    'ant-xl': {
       fontSize: `var(--${antPrefix}-font-size-xl)`,
     },
-    h1: {
+    'ant-h1': {
       fontSize: `var(--${antPrefix}-font-size-heading-1)`,
     },
-    h2: {
+    'ant-h2': {
       fontSize: `var(--${antPrefix}-font-size-heading-2)`,
     },
-    h3: {
+    'ant-h3': {
       fontSize: `var(--${antPrefix}-font-size-heading-3)`,
     },
   }

--- a/packages/unocss/src/preset.test.ts
+++ b/packages/unocss/src/preset.test.ts
@@ -41,6 +41,28 @@ describe('presetAntd', () => {
     expect(colors?.primary).toBeUndefined()
     expect(colors?.['a-primary']).toBeDefined()
   })
+
+  it('maps text-ant-* to Ant Design font-size variables without colliding with built-in text-sm', () => {
+    const preset = presetAntd()
+    const fontSize = (preset.theme as { fontSize?: Record<string, string> })?.fontSize
+
+    // ant-* keys exist
+    expect(fontSize?.['ant-sm']).toBe('var(--ant-font-size-sm)')
+    expect(fontSize?.['ant-lg']).toBe('var(--ant-font-size-lg)')
+    expect(fontSize?.['ant-xl']).toBe('var(--ant-font-size-xl)')
+    expect(fontSize?.['ant-h1']).toBe('var(--ant-font-size-heading-1)')
+    expect(fontSize?.['ant-base']).toBe('var(--ant-font-size)')
+
+    // conflicting short keys must NOT exist so built-in text-sm / text-lg are preserved
+    expect(fontSize?.['sm']).toBeUndefined()
+    expect(fontSize?.['lg']).toBeUndefined()
+    expect(fontSize?.['xl']).toBeUndefined()
+    expect(fontSize?.['DEFAULT']).toBeUndefined()
+
+    // rule matches text-ant-sm (Ant variable) but not plain text-sm
+    expect(hasMatchingRule(preset.rules as any[], 'text-ant-sm')).toBe(true)
+    expect(hasMatchingRule(preset.rules as any[], 'a-text-ant-sm')).toBe(true)
+  })
 })
 
 describe('presetAntdTailwind4', () => {
@@ -60,5 +82,27 @@ describe('presetAntdTailwind4', () => {
     expect(hasUnprefixedAutocomplete(preset.autocomplete?.templates as string[])).toBe(false)
     expect(colors?.primary).toBeUndefined()
     expect(colors?.['a-primary']).toBeDefined()
+  })
+
+  it('maps text-ant-* to Ant Design font-size variables without colliding with built-in text-sm', () => {
+    const preset = presetAntdTailwind4()
+    const text = (preset.theme as { text?: Record<string, { fontSize: string }> })?.text
+
+    // ant-* keys exist
+    expect(text?.['ant-sm']?.fontSize).toBe('var(--ant-font-size-sm)')
+    expect(text?.['ant-lg']?.fontSize).toBe('var(--ant-font-size-lg)')
+    expect(text?.['ant-xl']?.fontSize).toBe('var(--ant-font-size-xl)')
+    expect(text?.['ant-h1']?.fontSize).toBe('var(--ant-font-size-heading-1)')
+    expect(text?.['ant-base']?.fontSize).toBe('var(--ant-font-size)')
+
+    // conflicting short keys must NOT exist
+    expect(text?.['sm']).toBeUndefined()
+    expect(text?.['lg']).toBeUndefined()
+    expect(text?.['xl']).toBeUndefined()
+    expect(text?.['DEFAULT']).toBeUndefined()
+
+    // rule matches text-ant-sm (Ant variable)
+    expect(hasMatchingRule(preset.rules as any[], 'text-ant-sm')).toBe(true)
+    expect(hasMatchingRule(preset.rules as any[], 'a-text-ant-sm')).toBe(true)
   })
 })


### PR DESCRIPTION
`buildFontSizeTheme`/`buildTextTheme` used bare keys (`sm`, `lg`, `xl`, `h1`…) that, when `allowUnprefixed: true`, generated `text-sm`/`text-lg` rules that silently overrode the UnoCSS/Tailwind built-in rem scale.

## Changes

- **`common/theme.ts`** — Rename all font-size/text theme keys to `ant-*` (`ant-sm`, `ant-base`, `ant-lg`, `ant-xl`, `ant-h1`, `ant-h2`, `ant-h3`). The `DEFAULT` key is replaced by `ant-base`.
- **`common/autocomplete.ts`** — Update `FONT_ENUM` / `TEXT_ENUM` to reflect the new key names.
- **`preset.test.ts`** — Add assertions that bare keys (`sm`, `lg`, `DEFAULT`) are absent from the theme, `ant-*` keys resolve to the correct `var(--ant-font-size-*)` values, and the rule regex matches `text-ant-sm` / `a-text-ant-sm`.
- **`README.md`** — Document new `text-ant-*` utility names and explain the coexistence design.

## Before / After

```html
<!-- before: overrides UnoCSS built-in 0.875rem -->
<span class="text-sm">…</span>

<!-- after: built-in scale untouched; Ant token opt-in -->
<span class="text-sm">…</span>          <!-- → 0.875rem (UnoCSS built-in) ✅ -->
<span class="text-ant-sm">…</span>      <!-- → var(--ant-font-size-sm)     ✅ -->
<span class="a-text-ant-lg">…</span>    <!-- → var(--ant-font-size-lg)     ✅ -->
```

No changes to spacing, color, shadow, or border-radius tokens — only the font-size key namespace is affected.