### PR TITLE
feat(unocss): add namespace support for UnoCSS with token prefixing

### DIFF
--- a/examples/unocss-v4/src/App.vue
+++ b/examples/unocss-v4/src/App.vue
@@ -4,7 +4,11 @@ import { App } from "antdv-next"
 
 <template>
   <App>
-    <span class=""></span>
+    <div class="bg-ant-primary text-ant-sm rounded-ant-lg p-ant-lg shadow-ant-card">
+      namespace-safe
+    </div>
+    <div class="a-bg-primary a-text-sm a-rounded a-p-lg a-shadow-card">
+      prefixed
+    </div>
   </App>
 </template>
-

--- a/examples/unocss-v4/uno.config.ts
+++ b/examples/unocss-v4/uno.config.ts
@@ -19,7 +19,9 @@ export default defineConfig({
       scale: 1.2,
       warn: true,
     }),
-    presetAntdTailwind4(),
+    presetAntdTailwind4({
+      allowUnprefixed: false,
+    }),
   ],
   shortcuts: [],
   transformers: [transformerDirectives(), transformerVariantGroup()],

--- a/packages/unocss/README.md
+++ b/packages/unocss/README.md
@@ -25,8 +25,10 @@ export default defineConfig({
   presets: [
     presetAntd({
       prefix: 'a',      // class prefix, default: 'a'
-      allowUnprefixed: true, // support color-primary style classes, default: true
+      allowPrefixedUtilities: true, // keep a-* utilities, default: true
+      allowUnprefixed: true, // keep legacy bare classes like bg-primary, default: true
       antPrefix: 'ant', // CSS variable prefix, default: 'ant'
+      tokenPrefix: 'ant', // namespace-safe classes like bg-ant-primary, default: 'ant'
     }),
   ],
 })
@@ -51,8 +53,10 @@ export default defineConfig({
   presets: [
     presetAntdTailwind4({
       prefix: 'a',      // class prefix, default: 'a'
-      allowUnprefixed: true, // support color-primary style classes, default: true
+      allowPrefixedUtilities: true, // keep a-* utilities, default: true
+      allowUnprefixed: true, // keep legacy bare classes like bg-primary, default: true
       antPrefix: 'ant', // CSS variable prefix, default: 'ant'
+      tokenPrefix: 'ant', // namespace-safe classes like bg-ant-primary, default: 'ant'
     }),
   ],
 })
@@ -82,27 +86,22 @@ Both presets support the same utility class patterns:
 
 ```vue
 <template>
-  <!-- Colors -->
+  <!-- Stable prefixed APIs -->
   <div class="a-bg-primary a-color-white">Primary Background</div>
-  <div class="a-bg-container a-color-text">Container Background</div>
+  <div class="a-p-lg a-rounded-lg a-shadow-card">Prefixed</div>
 
-  <!-- Spacing -->
-  <div class="a-p-lg a-m-sm">Padding & Margin</div>
-  <div class="a-px-md a-py-xs">Directional Spacing</div>
-
-  <!-- Border -->
-  <div class="a-border-primary a-rounded-lg">Bordered & Rounded</div>
-  <div class="a-border-t-success">Top Border Color</div>
-
-  <!-- Shadow -->
-  <div class="a-shadow-card">Card Shadow</div>
-
-  <!-- Text -->
-  <div class="a-text-lg a-color-primary">Large Text</div>
+  <!-- Namespace-safe unprefixed APIs -->
+  <div class="bg-ant-primary color-ant text-ant-lg p-ant-lg rounded-ant-lg shadow-ant-card">
+    Namespace safe
+  </div>
 </template>
 ```
 
 > Note: this preset only customizes `m-*` / `p-*` related classes and does not override UnoCSS global spacing scale (`w-*`, `max-w-*`, `gap-*`, etc.).
+>
+> `allowUnprefixed: false` now disables only the legacy bare utilities such as `bg-primary` and `text-sm`. Prefixed `a-*` and namespace-safe `*-ant-*` utilities remain available.
+>
+> For parity with Tailwind PR #8, the preferred option names are `tokenPrefix` and `allowPrefixedUtilities`.
 
 ## When to Use Which?
 
@@ -123,6 +122,9 @@ Both presets support the same utility class patterns:
 - `a-color-{color}` / `a-c-{color}` - Text color
 - `a-bg-{color}` - Background color
 - `a-border-{color}` / `a-b-{color}` - Border color
+- `color-ant-{color}` / `c-ant-{color}` - Namespace-safe text color
+- `bg-ant-{color}` - Namespace-safe background color
+- `border-ant-{color}` / `b-ant-{color}` - Namespace-safe border color
 - Directional borders: `a-border-t-{color}`, `a-border-r-{color}`, etc.
 
 ### Spacing Utilities
@@ -132,19 +134,25 @@ Both presets support the same utility class patterns:
 - `a-p-{size}` - Padding
 - `a-pt-{size}`, `a-pr-{size}`, `a-pb-{size}`, `a-pl-{size}` - Directional padding
 - `a-px-{size}`, `a-py-{size}` - Horizontal/Vertical padding
+- `m-ant-{size}`, `mx-ant-{size}`, `p-ant-{size}`, `px-ant-{size}` - Namespace-safe spacing
 
 ### Border Radius Utilities
 - `a-rounded` / `a-rd` - Border radius
 - `a-rounded-{size}` / `a-rd-{size}` - Border radius with size
+- `rounded-ant` / `rd-ant` - Namespace-safe default border radius
+- `rounded-ant-{size}` / `rd-ant-{size}` - Namespace-safe border radius with size
 - Corner specific: `a-rounded-tl-{size}`, `a-rounded-tr-{size}`, etc.
 - Side specific: `a-rounded-t-{size}`, `a-rounded-r-{size}`, etc.
 
 ### Shadow Utilities
 - `a-shadow` - Default shadow
 - `a-shadow-{type}` - Specific shadow type (card, drawer-r, etc.)
+- `shadow-ant` - Namespace-safe default shadow
+- `shadow-ant-{type}` - Namespace-safe shadow type
 
 ### Text Utilities
 - `a-text-{size}` - Font size (sm, lg, xl, h1, h2, h3)
+- `text-ant-{size}` - Namespace-safe font size
 
 ## Available Theme Tokens
 

--- a/packages/unocss/README.zh-CN.md
+++ b/packages/unocss/README.zh-CN.md
@@ -25,8 +25,10 @@ export default defineConfig({
   presets: [
     presetAntd({
       prefix: 'a',      // class 前缀，默认: 'a'
-      allowUnprefixed: true, // 支持 color-primary 这类无前缀类名，默认: true
+      allowPrefixedUtilities: true, // 保留 a-* 工具类，默认: true
+      allowUnprefixed: true, // 保留 bg-primary 这类旧 bare 类，默认: true
       antPrefix: 'ant', // CSS 变量前缀，默认: 'ant'
+      tokenPrefix: 'ant', // 生成 bg-ant-primary 这类安全命名空间类，默认: 'ant'
     }),
   ],
 })
@@ -51,8 +53,10 @@ export default defineConfig({
   presets: [
     presetAntdTailwind4({
       prefix: 'a',      // class 前缀，默认: 'a'
-      allowUnprefixed: true, // 支持 color-primary 这类无前缀类名，默认: true
+      allowPrefixedUtilities: true, // 保留 a-* 工具类，默认: true
+      allowUnprefixed: true, // 保留 bg-primary 这类旧 bare 类，默认: true
       antPrefix: 'ant', // CSS 变量前缀，默认: 'ant'
+      tokenPrefix: 'ant', // 生成 bg-ant-primary 这类安全命名空间类，默认: 'ant'
     }),
   ],
 })
@@ -82,27 +86,22 @@ export default defineConfig({
 
 ```vue
 <template>
-  <!-- 颜色 -->
+  <!-- 稳定的前缀 API -->
   <div class="a-bg-primary a-color-white">主色背景</div>
-  <div class="a-bg-container a-color-text">容器背景</div>
+  <div class="a-p-lg a-rounded-lg a-shadow-card">带前缀</div>
 
-  <!-- 间距 -->
-  <div class="a-p-lg a-m-sm">内边距和外边距</div>
-  <div class="a-px-md a-py-xs">方向性间距</div>
-
-  <!-- 边框 -->
-  <div class="a-border-primary a-rounded-lg">边框和圆角</div>
-  <div class="a-border-t-success">顶部边框颜色</div>
-
-  <!-- 阴影 -->
-  <div class="a-shadow-card">卡片阴影</div>
-
-  <!-- 文字 -->
-  <div class="a-text-lg a-color-primary">大号文字</div>
+  <!-- 推荐的 namespace 安全 API -->
+  <div class="bg-ant-primary color-ant text-ant-lg p-ant-lg rounded-ant-lg shadow-ant-card">
+    namespace 安全
+  </div>
 </template>
 ```
 
 > 注意：该预设仅自定义 `m-*` / `p-*` 相关类，不会覆盖 UnoCSS 全局 spacing（`w-*`、`max-w-*`、`gap-*` 等保持默认行为）。
+>
+> `allowUnprefixed: false` 现在只会关闭 `bg-primary`、`text-sm` 这类旧 bare 类，不会影响 `a-*` 和 `*-ant-*`。
+>
+> 为了和 Tailwind 的 PR #8 对齐，推荐使用 `tokenPrefix` 和 `allowPrefixedUtilities` 这组配置名。
 
 ## 如何选择？
 
@@ -123,6 +122,9 @@ export default defineConfig({
 - `a-color-{color}` / `a-c-{color}` - 文字颜色
 - `a-bg-{color}` - 背景颜色
 - `a-border-{color}` / `a-b-{color}` - 边框颜色
+- `color-ant-{color}` / `c-ant-{color}` - namespace 安全的文字颜色
+- `bg-ant-{color}` - namespace 安全的背景颜色
+- `border-ant-{color}` / `b-ant-{color}` - namespace 安全的边框颜色
 - 方向性边框：`a-border-t-{color}`、`a-border-r-{color}` 等
 
 ### 间距工具类
@@ -132,19 +134,25 @@ export default defineConfig({
 - `a-p-{size}` - 内边距
 - `a-pt-{size}`、`a-pr-{size}`、`a-pb-{size}`、`a-pl-{size}` - 方向性内边距
 - `a-px-{size}`、`a-py-{size}` - 水平/垂直内边距
+- `m-ant-{size}`、`mx-ant-{size}`、`p-ant-{size}`、`px-ant-{size}` - namespace 安全间距
 
 ### 边框圆角工具类
 - `a-rounded` / `a-rd` - 边框圆角
 - `a-rounded-{size}` / `a-rd-{size}` - 指定大小的边框圆角
+- `rounded-ant` / `rd-ant` - namespace 安全默认圆角
+- `rounded-ant-{size}` / `rd-ant-{size}` - namespace 安全指定圆角
 - 角落特定：`a-rounded-tl-{size}`、`a-rounded-tr-{size}` 等
 - 边侧特定：`a-rounded-t-{size}`、`a-rounded-r-{size}` 等
 
 ### 阴影工具类
 - `a-shadow` - 默认阴影
 - `a-shadow-{type}` - 特定阴影类型（card、drawer-r 等）
+- `shadow-ant` - namespace 安全默认阴影
+- `shadow-ant-{type}` - namespace 安全特定阴影
 
 ### 文字工具类
 - `a-text-{size}` - 字体大小（sm、lg、xl、h1、h2、h3）
+- `text-ant-{size}` - namespace 安全字体大小
 
 ## 可用的主题标记
 

--- a/packages/unocss/src/common/autocomplete.ts
+++ b/packages/unocss/src/common/autocomplete.ts
@@ -7,6 +7,8 @@ import { colorNames } from './types'
 export interface AutocompleteOptions {
   prefix: string
   allowUnprefixed?: boolean
+  allowPrefixedUtilities?: boolean
+  tokenPrefix?: string
   themeKeys: {
     rounded: 'borderRadius' | 'radius'
     shadow: 'boxShadow' | 'shadow'
@@ -114,16 +116,103 @@ function createTemplatesForPrefix(prefix: string, themeKeys: AutocompleteOptions
   ]
 }
 
+function createNamespacedTemplates(tokenPrefix: string, themeKeys: AutocompleteOptions['themeKeys']) {
+  const ns = `${tokenPrefix}-`
+  const textEnum = themeKeys.text === 'text' ? TEXT_ENUM : FONT_ENUM
+
+  return [
+    `color-${tokenPrefix}`,
+    `color-${ns}${COLOR_ENUM}`,
+    `c-${tokenPrefix}`,
+    `c-${ns}${COLOR_ENUM}`,
+    `bg-${tokenPrefix}`,
+    `bg-${ns}${COLOR_ENUM}`,
+
+    `border-${tokenPrefix}`,
+    `border-${ns}${COLOR_ENUM}`,
+    `b-${tokenPrefix}`,
+    `b-${ns}${COLOR_ENUM}`,
+    `border-t-${tokenPrefix}`,
+    `border-t-${ns}${COLOR_ENUM}`,
+    `bt-${tokenPrefix}`,
+    `bt-${ns}${COLOR_ENUM}`,
+    `border-r-${tokenPrefix}`,
+    `border-r-${ns}${COLOR_ENUM}`,
+    `br-${tokenPrefix}`,
+    `br-${ns}${COLOR_ENUM}`,
+    `border-b-${tokenPrefix}`,
+    `border-b-${ns}${COLOR_ENUM}`,
+    `bb-${tokenPrefix}`,
+    `bb-${ns}${COLOR_ENUM}`,
+    `border-l-${tokenPrefix}`,
+    `border-l-${ns}${COLOR_ENUM}`,
+    `bl-${tokenPrefix}`,
+    `bl-${ns}${COLOR_ENUM}`,
+    `border-x-${tokenPrefix}`,
+    `border-x-${ns}${COLOR_ENUM}`,
+    `bx-${tokenPrefix}`,
+    `bx-${ns}${COLOR_ENUM}`,
+    `border-y-${tokenPrefix}`,
+    `border-y-${ns}${COLOR_ENUM}`,
+    `by-${tokenPrefix}`,
+    `by-${ns}${COLOR_ENUM}`,
+
+    `m-${ns}${SPACING_ENUM}`,
+    `mt-${ns}${SPACING_ENUM}`,
+    `mb-${ns}${SPACING_ENUM}`,
+    `ml-${ns}${SPACING_ENUM}`,
+    `mr-${ns}${SPACING_ENUM}`,
+    `mx-${ns}${SPACING_ENUM}`,
+    `my-${ns}${SPACING_ENUM}`,
+
+    `p-${ns}${SPACING_ENUM}`,
+    `pt-${ns}${SPACING_ENUM}`,
+    `pb-${ns}${SPACING_ENUM}`,
+    `pl-${ns}${SPACING_ENUM}`,
+    `pr-${ns}${SPACING_ENUM}`,
+    `px-${ns}${SPACING_ENUM}`,
+    `py-${ns}${SPACING_ENUM}`,
+
+    `text-${ns}${textEnum}`,
+
+    `rounded-${tokenPrefix}`,
+    `rd-${tokenPrefix}`,
+    `rounded-${ns}${RADIUS_ENUM}`,
+    `rd-${ns}${RADIUS_ENUM}`,
+    `rounded-tl-${tokenPrefix}`,
+    `rounded-tl-${ns}${RADIUS_ENUM}`,
+    `rounded-tr-${tokenPrefix}`,
+    `rounded-tr-${ns}${RADIUS_ENUM}`,
+    `rounded-bl-${tokenPrefix}`,
+    `rounded-bl-${ns}${RADIUS_ENUM}`,
+    `rounded-br-${tokenPrefix}`,
+    `rounded-br-${ns}${RADIUS_ENUM}`,
+    `rounded-t-${tokenPrefix}`,
+    `rounded-t-${ns}${RADIUS_ENUM}`,
+    `rounded-r-${tokenPrefix}`,
+    `rounded-r-${ns}${RADIUS_ENUM}`,
+    `rounded-b-${tokenPrefix}`,
+    `rounded-b-${ns}${RADIUS_ENUM}`,
+    `rounded-l-${tokenPrefix}`,
+    `rounded-l-${ns}${RADIUS_ENUM}`,
+
+    `shadow-${tokenPrefix}`,
+    `shadow-${ns}${SHADOW_ENUM}`,
+  ]
+}
+
 /**
  * 创建自动补全模板（同时支持带前缀和不带前缀）
  */
 export function createAutocompleteTemplates(options: AutocompleteOptions) {
-  const { prefix, allowUnprefixed = true, themeKeys } = options
+  const { prefix, allowUnprefixed = true, allowPrefixedUtilities = true, tokenPrefix = 'ant', themeKeys } = options
 
-  return [
+  return Array.from(new Set([
     // 带前缀的模板 (如 a-mx-lg)
-    ...createTemplatesForPrefix(prefix, themeKeys),
+    ...(allowPrefixedUtilities ? createTemplatesForPrefix(prefix, themeKeys) : []),
     // 不带前缀的模板 (如 mx-lg)
     ...(allowUnprefixed ? createTemplatesForPrefix('', themeKeys) : []),
-  ]
+    // 推荐的 namespace 安全模板 (如 text-ant-sm, bg-ant-primary)
+    ...createNamespacedTemplates(tokenPrefix, themeKeys),
+  ]))
 }

--- a/packages/unocss/src/common/rules.ts
+++ b/packages/unocss/src/common/rules.ts
@@ -2,82 +2,160 @@
  * 规则生成函数
  */
 
-function resolveThemeTokenKey(token: string, themeTokenPrefix?: string) {
-  if (!themeTokenPrefix)
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function resolveTokenKey(token: string, tokenPrefix?: string) {
+  if (!tokenPrefix)
     return token
 
-  return `${themeTokenPrefix}-${token}`
+  if (token === tokenPrefix)
+    return 'DEFAULT'
+
+  const namespacePrefix = `${tokenPrefix}-`
+  if (token.startsWith(namespacePrefix))
+    return token.slice(namespacePrefix.length)
+
+  return token
+}
+
+function createThemeValueResolver(themeKey: string, tokenPrefix?: string) {
+  return (token: string, theme: any) => (theme[themeKey] as any)?.[resolveTokenKey(token, tokenPrefix)]
 }
 
 /**
  * 创建颜色类规则
  */
-export function createColorRules(prefix: string, themeTokenPrefix?: string) {
+export function createColorRules(prefix: string, tokenPrefix?: string, allowUnprefixed = true, allowPrefixedUtilities = true) {
   const p = prefix ? `${prefix}-` : ''
-  
-  return [
-    // ${prefix}-color-primary 或 ${prefix}-c-primary -> color: var(--${antPrefix}-color-primary)
-    [new RegExp(`^${p}(?:color|c)-(.+)$`), ([_, c]: [any, any], { theme }: any) => {
-      const color = (theme.colors as any)?.[resolveThemeTokenKey(c!, themeTokenPrefix)]
-      if (color)
-        return { color }
-    }],
+  const ns = tokenPrefix ? escapeRegExp(tokenPrefix) : ''
+  const resolveColor = (token: string, theme: any) => (theme.colors as any)?.[resolveTokenKey(token, tokenPrefix)]
+  const rules: any[] = []
 
-    // ${prefix}-bg-container -> background-color: var(--${antPrefix}-color-bg-container)
-    [new RegExp(`^${p}bg-(.+)$`), ([_, c]: [any, any], { theme }: any) => {
-      const color = (theme.colors as any)?.[resolveThemeTokenKey(c!, themeTokenPrefix)]
-      if (color)
-        return { 'background-color': color }
-    }],
-  ]
+  if (allowPrefixedUtilities) {
+    rules.push(
+      [new RegExp(`^${p}(?:color|c)-(.+)$`), ([_, token]: [any, any], { theme }: any) => {
+        const color = resolveColor(token!, theme)
+        if (color)
+          return { color }
+      }],
+      [new RegExp(`^${p}bg-(.+)$`), ([_, token]: [any, any], { theme }: any) => {
+        const color = resolveColor(token!, theme)
+        if (color)
+          return { 'background-color': color }
+      }],
+    )
+  }
+
+  if (allowUnprefixed) {
+    rules.push(
+      [new RegExp(`^(?:color|c)-(.+)$`), ([_, token]: [any, any], { theme }: any) => {
+        const color = resolveColor(token!, theme)
+        if (color)
+          return { color }
+      }],
+      [new RegExp(`^bg-(.+)$`), ([_, token]: [any, any], { theme }: any) => {
+        const color = resolveColor(token!, theme)
+        if (color)
+          return { 'background-color': color }
+      }],
+    )
+  }
+
+  if (tokenPrefix) {
+    rules.push(
+      [new RegExp(`^(?:color|c)-${ns}(?:-(.+))?$`), ([_, token]: [any, any], { theme }: any) => {
+        const color = resolveColor(token ? `${tokenPrefix}-${token}` : tokenPrefix, theme)
+        if (color)
+          return { color }
+      }],
+      [new RegExp(`^bg-${ns}(?:-(.+))?$`), ([_, token]: [any, any], { theme }: any) => {
+        const color = resolveColor(token ? `${tokenPrefix}-${token}` : tokenPrefix, theme)
+        if (color)
+          return { 'background-color': color }
+      }],
+    )
+  }
+
+  return rules
 }
 
 /**
  * 创建边框颜色规则
  */
-export function createBorderRules(prefix: string, themeTokenPrefix?: string) {
+export function createBorderRules(prefix: string, tokenPrefix?: string, allowUnprefixed = true, allowPrefixedUtilities = true) {
   const p = prefix ? `${prefix}-` : ''
-  
-  return [
-    // ${prefix}-border-primary 或 ${prefix}-b-primary -> border-color: ...
-    [new RegExp(`^${p}(?:border|b)-(.+)$`), ([_, c]: [any, any], { theme }: any) => {
-      const color = (theme.colors as any)?.[resolveThemeTokenKey(c!, themeTokenPrefix)]
+  const ns = tokenPrefix ? escapeRegExp(tokenPrefix) : ''
+  const resolveColor = (token: string, theme: any) => (theme.colors as any)?.[resolveTokenKey(token, tokenPrefix)]
+  const rules: any[] = []
+
+  if (allowPrefixedUtilities) {
+    rules.push([new RegExp(`^${p}(?:border|b)-(.+)$`), ([_, token]: [any, any], { theme }: any) => {
+      const color = resolveColor(token!, theme)
       if (color)
         return { 'border-color': color }
-    }],
-    // 方向性 border: bt/border-t, br/border-r, bb/border-b, bl/border-l
-    [new RegExp(`^${p}(?:border-t|bt)-(.+)$`), ([_, c]: [any, any], { theme }: any) => {
-      const color = (theme.colors as any)?.[resolveThemeTokenKey(c!, themeTokenPrefix)]
+    }])
+  }
+
+  if (allowUnprefixed) {
+    rules.push([new RegExp(`^(?:border|b)-(.+)$`), ([_, token]: [any, any], { theme }: any) => {
+      const color = resolveColor(token!, theme)
       if (color)
-        return { 'border-top-color': color }
-    }],
-    [new RegExp(`^${p}(?:border-r|br)-(.+)$`), ([_, c]: [any, any], { theme }: any) => {
-      const color = (theme.colors as any)?.[resolveThemeTokenKey(c!, themeTokenPrefix)]
+        return { 'border-color': color }
+    }])
+  }
+
+  if (tokenPrefix) {
+    rules.push([new RegExp(`^(?:border|b)-${ns}(?:-(.+))?$`), ([_, token]: [any, any], { theme }: any) => {
+      const color = resolveColor(token ? `${tokenPrefix}-${token}` : tokenPrefix, theme)
       if (color)
-        return { 'border-right-color': color }
-    }],
-    [new RegExp(`^${p}(?:border-b|bb)-(.+)$`), ([_, c]: [any, any], { theme }: any) => {
-      const color = (theme.colors as any)?.[resolveThemeTokenKey(c!, themeTokenPrefix)]
-      if (color)
-        return { 'border-bottom-color': color }
-    }],
-    [new RegExp(`^${p}(?:border-l|bl)-(.+)$`), ([_, c]: [any, any], { theme }: any) => {
-      const color = (theme.colors as any)?.[resolveThemeTokenKey(c!, themeTokenPrefix)]
-      if (color)
-        return { 'border-left-color': color }
-    }],
-    // 双向 border: bx/border-x, by/border-y
-    [new RegExp(`^${p}(?:border-x|bx)-(.+)$`), ([_, c]: [any, any], { theme }: any) => {
-      const color = (theme.colors as any)?.[resolveThemeTokenKey(c!, themeTokenPrefix)]
-      if (color)
-        return { 'border-left-color': color, 'border-right-color': color }
-    }],
-    [new RegExp(`^${p}(?:border-y|by)-(.+)$`), ([_, c]: [any, any], { theme }: any) => {
-      const color = (theme.colors as any)?.[resolveThemeTokenKey(c!, themeTokenPrefix)]
-      if (color)
-        return { 'border-top-color': color, 'border-bottom-color': color }
-    }],
-  ]
+        return { 'border-color': color }
+    }])
+  }
+
+  const directions = [
+    ['border-t', 'bt', ['border-top-color']],
+    ['border-r', 'br', ['border-right-color']],
+    ['border-b', 'bb', ['border-bottom-color']],
+    ['border-l', 'bl', ['border-left-color']],
+    ['border-x', 'bx', ['border-left-color', 'border-right-color']],
+    ['border-y', 'by', ['border-top-color', 'border-bottom-color']],
+  ] as const
+
+  for (const [full, short, props] of directions) {
+    if (allowPrefixedUtilities) {
+      rules.push([new RegExp(`^${p}(?:${full}|${short})-(.+)$`), ([_, token]: [any, any], { theme }: any) => {
+        const color = resolveColor(token!, theme)
+        if (!color)
+          return
+
+        return Object.fromEntries(props.map(prop => [prop, color]))
+      }])
+    }
+
+    if (allowUnprefixed) {
+      rules.push([new RegExp(`^(?:${full}|${short})-(.+)$`), ([_, token]: [any, any], { theme }: any) => {
+        const color = resolveColor(token!, theme)
+        if (!color)
+          return
+
+        return Object.fromEntries(props.map(prop => [prop, color]))
+      }])
+    }
+
+    if (tokenPrefix) {
+      rules.push([new RegExp(`^(?:${full}|${short})-${ns}(?:-(.+))?$`), ([_, token]: [any, any], { theme }: any) => {
+        const color = resolveColor(token ? `${tokenPrefix}-${token}` : tokenPrefix, theme)
+        if (!color)
+          return
+
+        return Object.fromEntries(props.map(prop => [prop, color]))
+      }])
+    }
+  }
+
+  return rules
 }
 
 /**
@@ -94,62 +172,56 @@ function getMarginVar(antPrefix: string, token: string) {
   return `var(--${antPrefix}-margin-${token})`
 }
 
-export function createSpacingRules(prefix: string, antPrefix: string) {
+export function createSpacingRules(prefix: string, antPrefix: string, tokenPrefix?: string, allowUnprefixed = true, allowPrefixedUtilities = true) {
   const p = prefix ? `${prefix}-` : ''
-  
-  return [
-    // --- Margin ---
-    // ${prefix}-m-sm -> margin: 12px (var)
-    [new RegExp(`^${p}m-${spacingTokenPattern}$`), ([_, s]: [any, any]) => {
-      return { margin: getMarginVar(antPrefix, s) }
-    }],
-    // ${prefix}-mt-lg -> margin-top: 24px (var)
-    [new RegExp(`^${p}mt-${spacingTokenPattern}$`), ([_, s]: [any, any]) => {
-      return { 'margin-top': getMarginVar(antPrefix, s) }
-    }],
-    [new RegExp(`^${p}mb-${spacingTokenPattern}$`), ([_, s]: [any, any]) => {
-      return { 'margin-bottom': getMarginVar(antPrefix, s) }
-    }],
-    [new RegExp(`^${p}ml-${spacingTokenPattern}$`), ([_, s]: [any, any]) => {
-      return { 'margin-left': getMarginVar(antPrefix, s) }
-    }],
-    [new RegExp(`^${p}mr-${spacingTokenPattern}$`), ([_, s]: [any, any]) => {
-      return { 'margin-right': getMarginVar(antPrefix, s) }
-    }],
-    [new RegExp(`^${p}mx-${spacingTokenPattern}$`), ([_, s]: [any, any]) => {
-      const v = getMarginVar(antPrefix, s)
-      return { 'margin-left': v, 'margin-right': v }
-    }],
-    [new RegExp(`^${p}my-${spacingTokenPattern}$`), ([_, s]: [any, any]) => {
-      const v = getMarginVar(antPrefix, s)
-      return { 'margin-top': v, 'margin-bottom': v }
-    }],
+  const ns = tokenPrefix ? `${escapeRegExp(tokenPrefix)}-` : ''
+  const utilities = [
+    ['m', 'margin', getMarginVar],
+    ['mt', 'margin-top', getMarginVar],
+    ['mb', 'margin-bottom', getMarginVar],
+    ['ml', 'margin-left', getMarginVar],
+    ['mr', 'margin-right', getMarginVar],
+    ['mx', ['margin-left', 'margin-right'], getMarginVar],
+    ['my', ['margin-top', 'margin-bottom'], getMarginVar],
+    ['p', 'padding', getPaddingVar],
+    ['pt', 'padding-top', getPaddingVar],
+    ['pb', 'padding-bottom', getPaddingVar],
+    ['pl', 'padding-left', getPaddingVar],
+    ['pr', 'padding-right', getPaddingVar],
+    ['px', ['padding-left', 'padding-right'], getPaddingVar],
+    ['py', ['padding-top', 'padding-bottom'], getPaddingVar],
+  ] as const
 
-    // --- Padding ---
-    [new RegExp(`^${p}p-${spacingTokenPattern}$`), ([_, s]: [any, any]) => {
-      return { padding: getPaddingVar(antPrefix, s) }
-    }],
-    [new RegExp(`^${p}pt-${spacingTokenPattern}$`), ([_, s]: [any, any]) => {
-      return { 'padding-top': getPaddingVar(antPrefix, s) }
-    }],
-    [new RegExp(`^${p}pb-${spacingTokenPattern}$`), ([_, s]: [any, any]) => {
-      return { 'padding-bottom': getPaddingVar(antPrefix, s) }
-    }],
-    [new RegExp(`^${p}pl-${spacingTokenPattern}$`), ([_, s]: [any, any]) => {
-      return { 'padding-left': getPaddingVar(antPrefix, s) }
-    }],
-    [new RegExp(`^${p}pr-${spacingTokenPattern}$`), ([_, s]: [any, any]) => {
-      return { 'padding-right': getPaddingVar(antPrefix, s) }
-    }],
-    [new RegExp(`^${p}px-${spacingTokenPattern}$`), ([_, s]: [any, any]) => {
-      const v = getPaddingVar(antPrefix, s)
-      return { 'padding-left': v, 'padding-right': v }
-    }],
-    [new RegExp(`^${p}py-${spacingTokenPattern}$`), ([_, s]: [any, any]) => {
-      const v = getPaddingVar(antPrefix, s)
-      return { 'padding-top': v, 'padding-bottom': v }
-    }],
-  ]
+  const createStyle = (prop: string | readonly string[], token: string, getter: typeof getPaddingVar) => {
+    const value = getter(antPrefix, token)
+    if (Array.isArray(prop))
+      return Object.fromEntries(prop.map(key => [key, value]))
+    return { [prop]: value }
+  }
+
+  const rules: any[] = []
+
+  for (const [utility, prop, getter] of utilities) {
+    if (allowPrefixedUtilities) {
+      rules.push([new RegExp(`^${p}${utility}-${spacingTokenPattern}$`), ([_, token]: [any, any]) => {
+        return createStyle(prop, token!, getter)
+      }])
+    }
+
+    if (allowUnprefixed) {
+      rules.push([new RegExp(`^${utility}-${spacingTokenPattern}$`), ([_, token]: [any, any]) => {
+        return createStyle(prop, token!, getter)
+      }])
+    }
+
+    if (tokenPrefix) {
+      rules.push([new RegExp(`^${utility}-${ns}${spacingTokenPattern}$`), ([_, token]: [any, any]) => {
+        return createStyle(prop, token!, getter)
+      }])
+    }
+  }
+
+  return rules
 }
 
 /**
@@ -157,26 +229,46 @@ export function createSpacingRules(prefix: string, antPrefix: string) {
  * @param prefix class 前缀
  * @param themeKey 主题键名，'fontSize' 或 'text'
  */
-export function createTextRules(prefix: string, themeKey: 'fontSize' | 'text' = 'fontSize', themeTokenPrefix?: string) {
+export function createTextRules(prefix: string, themeKey: 'fontSize' | 'text' = 'fontSize', tokenPrefix?: string, allowUnprefixed = true, allowPrefixedUtilities = true) {
   const p = prefix ? `${prefix}-` : ''
-  
-  return [
-    // ${prefix}-text-lg -> font-size: 16px (var)
-    [new RegExp(`^${p}text-(.+)$`), ([_, s]: [any, any], { theme }: any) => {
-      const key = resolveThemeTokenKey(s!, themeTokenPrefix)
-      if (themeKey === 'fontSize') {
-        const v = (theme.fontSize as any)?.[key]
-        if (v)
-          return { 'font-size': v }
-      }
-      else {
-        const textConfig = (theme.text as any)?.[key]
-        if (textConfig?.fontSize) {
-          return { 'font-size': textConfig.fontSize }
-        }
-      }
-    }],
-  ]
+  const ns = tokenPrefix ? `${escapeRegExp(tokenPrefix)}-` : ''
+  const rules: any[] = []
+  const resolveValue = (token: string, theme: any) => {
+    const key = resolveTokenKey(token, tokenPrefix)
+    if (themeKey === 'fontSize')
+      return (theme.fontSize as any)?.[key]
+    return (theme.text as any)?.[key]?.fontSize
+  }
+
+  if (allowPrefixedUtilities) {
+    rules.push([new RegExp(`^${p}text-(.+)$`), ([_, token]: [any, any], { theme }: any) => {
+      const value = resolveValue(token!, theme)
+      if (value)
+        return { 'font-size': value }
+    }])
+  }
+
+  if (allowUnprefixed) {
+    rules.push([new RegExp(`^text-(.+)$`), ([_, token]: [any, any], { theme }: any) => {
+      const value = resolveValue(token!, theme)
+      if (value)
+        return { 'font-size': value }
+    }])
+  }
+
+  if (tokenPrefix) {
+    rules.push([new RegExp(`^text-${ns}(.+)$`), ([_, token]: [any, any], { theme }: any) => {
+      const value = resolveValue(`${tokenPrefix}-${token!}`, theme)
+      if (value)
+        return { 'font-size': value }
+    }])
+  }
+
+  return rules
+}
+
+function buildRadiusStyle(props: string[], value: string) {
+  return Object.fromEntries(props.map(prop => [prop, value]))
 }
 
 /**
@@ -184,65 +276,116 @@ export function createTextRules(prefix: string, themeKey: 'fontSize' | 'text' = 
  * @param prefix class 前缀
  * @param themeKey 主题键名，'borderRadius' 或 'radius'
  */
-export function createRoundedRules(prefix: string, themeKey: 'borderRadius' | 'radius' = 'borderRadius', themeTokenPrefix?: string) {
+export function createRoundedRules(prefix: string, themeKey: 'borderRadius' | 'radius' = 'borderRadius', tokenPrefix?: string, allowUnprefixed = true, allowPrefixedUtilities = true) {
   const p = prefix ? `${prefix}-` : ''
-  
-  return [
-    // ${prefix}-rounded -> border-radius: var(--${antPrefix}-border-radius) (DEFAULT)
-    [new RegExp(`^${p}(?:rounded|rd)$`), (_: any, { theme }: any) => {
-      const v = (theme[themeKey] as any)?.[resolveThemeTokenKey('DEFAULT', themeTokenPrefix)]
-      if (v)
-        return { 'border-radius': v }
-    }],
-    // ${prefix}-rounded-sm 或 ${prefix}-rd-sm -> border-radius: 4px (var)
-    [new RegExp(`^${p}(?:rounded|rd)-(.+)$`), ([_, s]: [any, any], { theme }: any) => {
-      const v = (theme[themeKey] as any)?.[resolveThemeTokenKey(s!, themeTokenPrefix)]
-      if (v)
-        return { 'border-radius': v }
-    }],
-    // 角落圆角: rounded-tl, rounded-tr, rounded-bl, rounded-br (简写: rd-tl, rd-tr, rd-bl, rd-br)
-    [new RegExp(`^${p}(?:rounded|rd)-tl(?:-(.+))?$`), ([_, s]: [any, any], { theme }: any) => {
-      const v = (theme[themeKey] as any)?.[resolveThemeTokenKey(s || 'DEFAULT', themeTokenPrefix)]
-      if (v)
-        return { 'border-top-left-radius': v }
-    }],
-    [new RegExp(`^${p}(?:rounded|rd)-tr(?:-(.+))?$`), ([_, s]: [any, any], { theme }: any) => {
-      const v = (theme[themeKey] as any)?.[resolveThemeTokenKey(s || 'DEFAULT', themeTokenPrefix)]
-      if (v)
-        return { 'border-top-right-radius': v }
-    }],
-    [new RegExp(`^${p}(?:rounded|rd)-bl(?:-(.+))?$`), ([_, s]: [any, any], { theme }: any) => {
-      const v = (theme[themeKey] as any)?.[resolveThemeTokenKey(s || 'DEFAULT', themeTokenPrefix)]
-      if (v)
-        return { 'border-bottom-left-radius': v }
-    }],
-    [new RegExp(`^${p}(?:rounded|rd)-br(?:-(.+))?$`), ([_, s]: [any, any], { theme }: any) => {
-      const v = (theme[themeKey] as any)?.[resolveThemeTokenKey(s || 'DEFAULT', themeTokenPrefix)]
-      if (v)
-        return { 'border-bottom-right-radius': v }
-    }],
-    // 边侧圆角: rounded-t, rounded-r, rounded-b, rounded-l (简写: rd-t, rd-r, rd-b, rd-l)
-    [new RegExp(`^${p}(?:rounded|rd)-t(?:-(.+))?$`), ([_, s]: [any, any], { theme }: any) => {
-      const v = (theme[themeKey] as any)?.[resolveThemeTokenKey(s || 'DEFAULT', themeTokenPrefix)]
-      if (v)
-        return { 'border-top-left-radius': v, 'border-top-right-radius': v }
-    }],
-    [new RegExp(`^${p}(?:rounded|rd)-r(?:-(.+))?$`), ([_, s]: [any, any], { theme }: any) => {
-      const v = (theme[themeKey] as any)?.[resolveThemeTokenKey(s || 'DEFAULT', themeTokenPrefix)]
-      if (v)
-        return { 'border-top-right-radius': v, 'border-bottom-right-radius': v }
-    }],
-    [new RegExp(`^${p}(?:rounded|rd)-b(?:-(.+))?$`), ([_, s]: [any, any], { theme }: any) => {
-      const v = (theme[themeKey] as any)?.[resolveThemeTokenKey(s || 'DEFAULT', themeTokenPrefix)]
-      if (v)
-        return { 'border-bottom-left-radius': v, 'border-bottom-right-radius': v }
-    }],
-    [new RegExp(`^${p}(?:rounded|rd)-l(?:-(.+))?$`), ([_, s]: [any, any], { theme }: any) => {
-      const v = (theme[themeKey] as any)?.[resolveThemeTokenKey(s || 'DEFAULT', themeTokenPrefix)]
-      if (v)
-        return { 'border-top-left-radius': v, 'border-bottom-left-radius': v }
-    }],
-  ]
+  const ns = tokenPrefix ? escapeRegExp(tokenPrefix) : ''
+  const resolveRadius = createThemeValueResolver(themeKey, tokenPrefix)
+  const rules: any[] = []
+
+  if (allowPrefixedUtilities) {
+    rules.push(
+      [new RegExp(`^${p}(?:rounded|rd)$`), (_: any, { theme }: any) => {
+        const value = resolveRadius('DEFAULT', theme)
+        if (value)
+          return { 'border-radius': value }
+      }],
+      [new RegExp(`^${p}(?:rounded|rd)-(.+)$`), ([_, token]: [any, any], { theme }: any) => {
+        const value = resolveRadius(token!, theme)
+        if (value)
+          return { 'border-radius': value }
+      }],
+    )
+  }
+
+  if (allowUnprefixed) {
+    rules.push(
+      [new RegExp(`^(?:rounded|rd)$`), (_: any, { theme }: any) => {
+        const value = resolveRadius('DEFAULT', theme)
+        if (value)
+          return { 'border-radius': value }
+      }],
+      [new RegExp(`^(?:rounded|rd)-(.+)$`), ([_, token]: [any, any], { theme }: any) => {
+        const value = resolveRadius(token!, theme)
+        if (value)
+          return { 'border-radius': value }
+      }],
+    )
+  }
+
+  if (tokenPrefix) {
+    rules.push(
+      [new RegExp(`^(?:rounded|rd)-${ns}$`), (_: any, { theme }: any) => {
+        const value = resolveRadius(tokenPrefix, theme)
+        if (value)
+          return { 'border-radius': value }
+      }],
+      [new RegExp(`^(?:rounded|rd)-${ns}-(.+)$`), ([_, token]: [any, any], { theme }: any) => {
+        const value = resolveRadius(`${tokenPrefix}-${token!}`, theme)
+        if (value)
+          return { 'border-radius': value }
+      }],
+    )
+  }
+
+  const directions = [
+    ['tl', ['border-top-left-radius']],
+    ['tr', ['border-top-right-radius']],
+    ['bl', ['border-bottom-left-radius']],
+    ['br', ['border-bottom-right-radius']],
+    ['t', ['border-top-left-radius', 'border-top-right-radius']],
+    ['r', ['border-top-right-radius', 'border-bottom-right-radius']],
+    ['b', ['border-bottom-left-radius', 'border-bottom-right-radius']],
+    ['l', ['border-top-left-radius', 'border-bottom-left-radius']],
+  ] as const
+
+  for (const [suffix, props] of directions) {
+    if (allowPrefixedUtilities) {
+      rules.push(
+        [new RegExp(`^${p}(?:rounded|rd)-${suffix}$`), (_: any, { theme }: any) => {
+          const value = resolveRadius('DEFAULT', theme)
+          if (value)
+            return buildRadiusStyle([...props], value)
+        }],
+        [new RegExp(`^${p}(?:rounded|rd)-${suffix}-(.+)$`), ([_, token]: [any, any], { theme }: any) => {
+          const value = resolveRadius(token!, theme)
+          if (value)
+            return buildRadiusStyle([...props], value)
+        }],
+      )
+    }
+
+    if (allowUnprefixed) {
+      rules.push(
+        [new RegExp(`^(?:rounded|rd)-${suffix}$`), (_: any, { theme }: any) => {
+          const value = resolveRadius('DEFAULT', theme)
+          if (value)
+            return buildRadiusStyle([...props], value)
+        }],
+        [new RegExp(`^(?:rounded|rd)-${suffix}-(.+)$`), ([_, token]: [any, any], { theme }: any) => {
+          const value = resolveRadius(token!, theme)
+          if (value)
+            return buildRadiusStyle([...props], value)
+        }],
+      )
+    }
+
+    if (tokenPrefix) {
+      rules.push(
+        [new RegExp(`^(?:rounded|rd)-${suffix}-${ns}$`), (_: any, { theme }: any) => {
+          const value = resolveRadius(tokenPrefix, theme)
+          if (value)
+            return buildRadiusStyle([...props], value)
+        }],
+        [new RegExp(`^(?:rounded|rd)-${suffix}-${ns}-(.+)$`), ([_, token]: [any, any], { theme }: any) => {
+          const value = resolveRadius(`${tokenPrefix}-${token!}`, theme)
+          if (value)
+            return buildRadiusStyle([...props], value)
+        }],
+      )
+    }
+  }
+
+  return rules
 }
 
 /**
@@ -250,20 +393,35 @@ export function createRoundedRules(prefix: string, themeKey: 'borderRadius' | 'r
  * @param prefix class 前缀
  * @param themeKey 主题键名，'boxShadow' 或 'shadow'
  */
-export function createShadowRules(prefix: string, themeKey: 'boxShadow' | 'shadow' = 'boxShadow', themeTokenPrefix?: string) {
+export function createShadowRules(prefix: string, themeKey: 'boxShadow' | 'shadow' = 'boxShadow', tokenPrefix?: string, allowUnprefixed = true, allowPrefixedUtilities = true) {
   const p = prefix ? `${prefix}-` : ''
-  
-  return [
-    [
-      new RegExp(`^${p}shadow(?:-(.+))?$`),
-      ([_, s]: [any, any], { theme }: any) => {
-        // 如果 s 存在(有后缀)，用 s；如果 s 不存在(没后缀)，用 'DEFAULT'
-        const key = resolveThemeTokenKey(s || 'DEFAULT', themeTokenPrefix)
-        const v = (theme[themeKey] as any)?.[key]
+  const ns = tokenPrefix ? escapeRegExp(tokenPrefix) : ''
+  const resolveShadow = createThemeValueResolver(themeKey, tokenPrefix)
+  const rules: any[] = []
 
-        if (v)
-          return { 'box-shadow': v }
-      },
-    ],
-  ]
+  if (allowPrefixedUtilities) {
+    rules.push([new RegExp(`^${p}shadow(?:-(.+))?$`), ([_, token]: [any, any], { theme }: any) => {
+      const value = resolveShadow(token || 'DEFAULT', theme)
+      if (value)
+        return { 'box-shadow': value }
+    }])
+  }
+
+  if (allowUnprefixed) {
+    rules.push([new RegExp(`^shadow(?:-(.+))?$`), ([_, token]: [any, any], { theme }: any) => {
+      const value = resolveShadow(token || 'DEFAULT', theme)
+      if (value)
+        return { 'box-shadow': value }
+    }])
+  }
+
+  if (tokenPrefix) {
+    rules.push([new RegExp(`^shadow-${ns}(?:-(.+))?$`), ([_, token]: [any, any], { theme }: any) => {
+      const value = resolveShadow(token ? `${tokenPrefix}-${token}` : tokenPrefix, theme)
+      if (value)
+        return { 'box-shadow': value }
+    }])
+  }
+
+  return rules
 }

--- a/packages/unocss/src/common/types.ts
+++ b/packages/unocss/src/common/types.ts
@@ -10,9 +10,15 @@ export interface BasePresetOptions {
    */
   prefix?: string
   /**
-   * @desc 是否允许不带 prefix 的工具类
+   * @desc 是否保留带 prefix 的工具类
    * @default true
-   * @example allowUnprefixed: false -> 仅支持 class="a-bg-primary"
+   * @example allowPrefixedUtilities: false -> 不生成 class="a-bg-primary"
+   */
+  allowPrefixedUtilities?: boolean
+  /**
+   * @desc 是否允许旧的不带 prefix 的工具类
+   * @default true
+   * @example allowUnprefixed: false -> 不生成 class="bg-primary"
    */
   allowUnprefixed?: boolean
   /**
@@ -21,6 +27,12 @@ export interface BasePresetOptions {
    * @example antPrefix: 'my-app' -> var(--my-app-color-primary)
    */
   antPrefix?: string
+  /**
+   * @desc 无前缀工具类使用的 token 前缀
+   * @default 'ant'
+   * @example tokenPrefix: 'ant' -> class="bg-ant-primary"
+   */
+  tokenPrefix?: string
 }
 
 export const colorNames = [

--- a/packages/unocss/src/preset.test.ts
+++ b/packages/unocss/src/preset.test.ts
@@ -12,15 +12,35 @@ function hasMatchingRule(rules: any[] | undefined, utility: string) {
 }
 
 function hasUnprefixedAutocomplete(templates: string[] | undefined) {
-  return (templates ?? []).some(template =>
-    template.startsWith('color-')
-    || template.startsWith('c-')
-    || template.startsWith('bg-')
-    || template.startsWith('m-')
-    || template.startsWith('text-')
-    || template.startsWith('rounded')
-    || template.startsWith('shadow'),
-  )
+  const legacyPatterns = [
+    /^color-\(/,
+    /^c-\(/,
+    /^bg-\(/,
+    /^border-\(/,
+    /^b-\(/,
+    /^(?:border-[trblxy]|b[trblxy])-\(/,
+    /^(?:m|mt|mb|ml|mr|mx|my)-\(/,
+    /^(?:p|pt|pb|pl|pr|px|py)-\(/,
+    /^text-\(/,
+    /^(?:rounded|rd)(?:$|-\()/,
+    /^(?:rounded|rd)-[trbl](?:$|-\()/,
+    /^shadow(?:$|-\()/,
+  ]
+
+  return (templates ?? []).some(template => legacyPatterns.some(pattern => pattern.test(template)))
+}
+
+function resolveUtility(preset: any, utility: string) {
+  for (const rule of (preset.rules ?? [])) {
+    if (!Array.isArray(rule) || !(rule[0] instanceof RegExp) || typeof rule[1] !== 'function')
+      continue
+
+    const match = utility.match(rule[0])
+    if (!match)
+      continue
+
+    return rule[1](match, { theme: preset.theme ?? {} })
+  }
 }
 
 describe('presetAntd', () => {
@@ -28,18 +48,61 @@ describe('presetAntd', () => {
     const preset = presetAntd()
 
     expect(hasMatchingRule(preset.rules as any[], 'color-primary')).toBe(true)
+    expect(hasMatchingRule(preset.rules as any[], 'text-ant-sm')).toBe(true)
     expect(hasUnprefixedAutocomplete(preset.autocomplete?.templates as string[])).toBe(true)
   })
 
-  it('can disable unprefixed utilities', () => {
+  it('adds namespace-safe utilities without changing prefixed APIs', () => {
+    const preset = presetAntd()
+
+    expect(resolveUtility(preset, 'a-bg-primary')).toEqual({
+      'background-color': 'var(--ant-color-primary)',
+    })
+    expect(resolveUtility(preset, 'bg-ant-primary')).toEqual({
+      'background-color': 'var(--ant-color-primary)',
+    })
+    expect(resolveUtility(preset, 'p-ant-lg')).toEqual({
+      padding: 'var(--ant-padding-lg)',
+    })
+    expect(resolveUtility(preset, 'rounded-ant-sm')).toEqual({
+      'border-radius': 'var(--ant-border-radius-sm)',
+    })
+    expect(resolveUtility(preset, 'shadow-ant-card')).toEqual({
+      'box-shadow': 'var(--ant-box-shadow-card)',
+    })
+    expect(resolveUtility(preset, 'text-ant-sm')).toEqual({
+      'font-size': 'var(--ant-font-size-sm)',
+    })
+  })
+
+  it('accepts tailwind-aligned option names', () => {
+    const preset = presetAntd({
+      tokenPrefix: 'antd',
+      allowUnprefixed: false,
+      allowPrefixedUtilities: false,
+    })
+
+    expect(hasMatchingRule(preset.rules as any[], 'a-color-primary')).toBe(false)
+    expect(hasMatchingRule(preset.rules as any[], 'color-primary')).toBe(false)
+    expect(hasMatchingRule(preset.rules as any[], 'color-antd-primary')).toBe(true)
+    expect(resolveUtility(preset, 'color-antd-primary')).toEqual({
+      color: 'var(--ant-color-primary)',
+    })
+  })
+
+  it('can disable legacy bare utilities while preserving namespaced ones', () => {
     const preset = presetAntd({ allowUnprefixed: false })
     const colors = (preset.theme as { colors?: Record<string, string> })?.colors
 
     expect(hasMatchingRule(preset.rules as any[], 'a-color-primary')).toBe(true)
     expect(hasMatchingRule(preset.rules as any[], 'color-primary')).toBe(false)
+    expect(hasMatchingRule(preset.rules as any[], 'color-ant-primary')).toBe(true)
     expect(hasUnprefixedAutocomplete(preset.autocomplete?.templates as string[])).toBe(false)
-    expect(colors?.primary).toBeUndefined()
-    expect(colors?.['a-primary']).toBeDefined()
+    expect(colors?.primary).toBeDefined()
+    expect(colors?.['a-primary']).toBeUndefined()
+    expect(resolveUtility(preset, 'color-ant-primary')).toEqual({
+      color: 'var(--ant-color-primary)',
+    })
   })
 })
 
@@ -48,17 +111,22 @@ describe('presetAntdTailwind4', () => {
     const preset = presetAntdTailwind4()
 
     expect(hasMatchingRule(preset.rules as any[], 'color-primary')).toBe(true)
+    expect(hasMatchingRule(preset.rules as any[], 'rounded-ant-lg')).toBe(true)
     expect(hasUnprefixedAutocomplete(preset.autocomplete?.templates as string[])).toBe(true)
   })
 
-  it('can disable unprefixed utilities', () => {
+  it('can disable legacy bare utilities without rewriting theme keys', () => {
     const preset = presetAntdTailwind4({ allowUnprefixed: false })
     const colors = (preset.theme as { colors?: Record<string, string> })?.colors
 
     expect(hasMatchingRule(preset.rules as any[], 'a-color-primary')).toBe(true)
     expect(hasMatchingRule(preset.rules as any[], 'color-primary')).toBe(false)
+    expect(hasMatchingRule(preset.rules as any[], 'bg-ant-primary')).toBe(true)
     expect(hasUnprefixedAutocomplete(preset.autocomplete?.templates as string[])).toBe(false)
-    expect(colors?.primary).toBeUndefined()
-    expect(colors?.['a-primary']).toBeDefined()
+    expect(colors?.primary).toBeDefined()
+    expect(colors?.['a-primary']).toBeUndefined()
+    expect(resolveUtility(preset, 'text-ant-h1')).toEqual({
+      'font-size': 'var(--ant-font-size-heading-1)',
+    })
   })
 })

--- a/packages/unocss/src/preset.ts
+++ b/packages/unocss/src/preset.ts
@@ -7,7 +7,6 @@ import {
   buildFontSizeTheme,
   buildPalettes,
   buildShadowTheme,
-  withThemeTokenPrefix,
   createAutocompleteTemplates,
   createBorderRules,
   createColorRules,
@@ -23,9 +22,10 @@ export interface AntdPresetOptions extends BasePresetOptions {}
 
 export const presetAntd = definePreset((options?: AntdPresetOptions): Preset => {
   const prefix = options?.prefix || 'a'
+  const allowPrefixedUtilities = options?.allowPrefixedUtilities ?? true
   const allowUnprefixed = options?.allowUnprefixed ?? true
   const antPrefix = options?.antPrefix || 'ant'
-  const themeTokenPrefix = allowUnprefixed ? undefined : prefix
+  const tokenPrefix = options?.tokenPrefix || 'ant'
 
   // 根据 antPrefix 动态生成调色板
   const builtPalettes = buildPalettes(antPrefix)
@@ -33,37 +33,27 @@ export const presetAntd = definePreset((options?: AntdPresetOptions): Preset => 
   return {
     name: 'preset-antd',
     theme: {
-      colors: withThemeTokenPrefix(buildColorsTheme(antPrefix, builtPalettes), themeTokenPrefix),
-      borderRadius: withThemeTokenPrefix(buildBorderRadiusTheme(antPrefix), themeTokenPrefix),
-      fontSize: withThemeTokenPrefix(buildFontSizeTheme(antPrefix), themeTokenPrefix),
-      boxShadow: withThemeTokenPrefix(buildShadowTheme(antPrefix), themeTokenPrefix),
+      colors: buildColorsTheme(antPrefix, builtPalettes),
+      borderRadius: buildBorderRadiusTheme(antPrefix),
+      fontSize: buildFontSizeTheme(antPrefix),
+      boxShadow: buildShadowTheme(antPrefix),
     },
 
     // 自定义规则
     rules: ([
-      // 带前缀的规则 (如 a-mx-lg)
-      ...createColorRules(prefix, themeTokenPrefix),
-      ...createBorderRules(prefix, themeTokenPrefix),
-      ...createSpacingRules(prefix, antPrefix),
-      ...createTextRules(prefix, 'fontSize', themeTokenPrefix),
-      ...createRoundedRules(prefix, 'borderRadius', themeTokenPrefix),
-      ...createShadowRules(prefix, 'boxShadow', themeTokenPrefix),
-      // 可选的不带前缀规则 (如 mx-lg)
-      ...(allowUnprefixed
-        ? [
-            ...createColorRules(''),
-            ...createBorderRules(''),
-            ...createSpacingRules('', antPrefix),
-            ...createTextRules('', 'fontSize'),
-            ...createRoundedRules('', 'borderRadius'),
-            ...createShadowRules('', 'boxShadow'),
-          ]
-        : []),
+      ...createColorRules(prefix, tokenPrefix, allowUnprefixed, allowPrefixedUtilities),
+      ...createBorderRules(prefix, tokenPrefix, allowUnprefixed, allowPrefixedUtilities),
+      ...createSpacingRules(prefix, antPrefix, tokenPrefix, allowUnprefixed, allowPrefixedUtilities),
+      ...createTextRules(prefix, 'fontSize', tokenPrefix, allowUnprefixed, allowPrefixedUtilities),
+      ...createRoundedRules(prefix, 'borderRadius', tokenPrefix, allowUnprefixed, allowPrefixedUtilities),
+      ...createShadowRules(prefix, 'boxShadow', tokenPrefix, allowUnprefixed, allowPrefixedUtilities),
     ] as any),
     autocomplete: {
       templates: createAutocompleteTemplates({
         prefix,
         allowUnprefixed,
+        allowPrefixedUtilities,
+        tokenPrefix,
         themeKeys: {
           rounded: 'borderRadius',
           shadow: 'boxShadow',

--- a/packages/unocss/src/presetTailwind4.ts
+++ b/packages/unocss/src/presetTailwind4.ts
@@ -7,7 +7,6 @@ import {
   buildRadiusTheme,
   buildShadowTheme,
   buildTextTheme,
-  withThemeTokenPrefix,
   createAutocompleteTemplates,
   createBorderRules,
   createColorRules,
@@ -23,9 +22,10 @@ export interface AntdPresetTailwind4Options extends BasePresetOptions {}
 
 export const presetAntdTailwind4 = definePreset((options?: AntdPresetTailwind4Options): Preset => {
   const prefix = options?.prefix || 'a'
+  const allowPrefixedUtilities = options?.allowPrefixedUtilities ?? true
   const allowUnprefixed = options?.allowUnprefixed ?? true
   const antPrefix = options?.antPrefix || 'ant'
-  const themeTokenPrefix = allowUnprefixed ? undefined : prefix
+  const tokenPrefix = options?.tokenPrefix || 'ant'
 
   // 根据 antPrefix 动态生成调色板
   const builtPalettes = buildPalettes(antPrefix)
@@ -33,39 +33,29 @@ export const presetAntdTailwind4 = definePreset((options?: AntdPresetTailwind4Op
   return {
     name: 'preset-antd-tailwind4',
     theme: {
-      colors: withThemeTokenPrefix(buildColorsTheme(antPrefix, builtPalettes), themeTokenPrefix),
-      radius: withThemeTokenPrefix(buildRadiusTheme(antPrefix), themeTokenPrefix),
-      text: withThemeTokenPrefix(buildTextTheme(antPrefix), themeTokenPrefix),
-      shadow: withThemeTokenPrefix(buildShadowTheme(antPrefix), themeTokenPrefix),
+      colors: buildColorsTheme(antPrefix, builtPalettes),
+      radius: buildRadiusTheme(antPrefix),
+      text: buildTextTheme(antPrefix),
+      shadow: buildShadowTheme(antPrefix),
       // Tailwind 4 新增的 defaults 配置
       defaults: {},
     },
 
     // 自定义规则
     rules: ([
-      // 带前缀的规则 (如 a-mx-lg)
-      ...createColorRules(prefix, themeTokenPrefix),
-      ...createBorderRules(prefix, themeTokenPrefix),
-      ...createSpacingRules(prefix, antPrefix),
-      ...createTextRules(prefix, 'text', themeTokenPrefix),
-      ...createRoundedRules(prefix, 'radius', themeTokenPrefix),
-      ...createShadowRules(prefix, 'shadow', themeTokenPrefix),
-      // 可选的不带前缀规则 (如 mx-lg)
-      ...(allowUnprefixed
-        ? [
-            ...createColorRules(''),
-            ...createBorderRules(''),
-            ...createSpacingRules('', antPrefix),
-            ...createTextRules('', 'text'),
-            ...createRoundedRules('', 'radius'),
-            ...createShadowRules('', 'shadow'),
-          ]
-        : []),
+      ...createColorRules(prefix, tokenPrefix, allowUnprefixed, allowPrefixedUtilities),
+      ...createBorderRules(prefix, tokenPrefix, allowUnprefixed, allowPrefixedUtilities),
+      ...createSpacingRules(prefix, antPrefix, tokenPrefix, allowUnprefixed, allowPrefixedUtilities),
+      ...createTextRules(prefix, 'text', tokenPrefix, allowUnprefixed, allowPrefixedUtilities),
+      ...createRoundedRules(prefix, 'radius', tokenPrefix, allowUnprefixed, allowPrefixedUtilities),
+      ...createShadowRules(prefix, 'shadow', tokenPrefix, allowUnprefixed, allowPrefixedUtilities),
     ] as any),
     autocomplete: {
       templates: createAutocompleteTemplates({
         prefix,
         allowUnprefixed,
+        allowPrefixedUtilities,
+        tokenPrefix,
         themeKeys: {
           rounded: 'radius',
           shadow: 'shadow',


### PR DESCRIPTION
## Summary

UnoCSS 版本命名空间支持，对应 Tailwind 版本 PR #8，共同实现 Issue #7 的 Antdv Next Token 命名空间设计。

- 引入 `prefix` 配置项，支持为工具类添加命名空间前缀（如 `a-text-sm`、`a-p-lg`）
- `allowUnprefixed` 控制是否同时生成无前缀版本
- Token 级别前缀隔离，避免 Antdv Next token 污染 UnoCSS 原生命名空间
- 完善类型定义和 `autocomplete` 支持

## Related

- Ref #7 (RFC: Antdv Next Token 工具类命名空间设计)
- Related to #8 (Tailwind CSS v4 对应实现)

## Test plan

- [ ] 设置 `prefix: 'a-'`，验证生成 `a-text-sm` 等带前缀工具类
- [ ] 设置 `allowUnprefixed: true`，验证同时生成有/无前缀版本
- [ ] 设置 `prefix: 'a-'` + `allowUnprefixed: false`，验证只生成带前缀版本
- [ ] 不设置 prefix，验证行为与之前一致（无前缀）
